### PR TITLE
Delta Encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,9 @@ name = "bitpacking"
 harness = false
 
 [[bench]]
+name = "delta"
+harness = false
+
+[[bench]]
 name = "transpose"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,7 @@ all = "deny"
 [[bench]]
 name = "bitpacking"
 harness = false
+
+[[bench]]
+name = "transpose"
+harness = false

--- a/benches/delta.rs
+++ b/benches/delta.rs
@@ -1,0 +1,44 @@
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+
+use arrayref::array_ref;
+use std::any::type_name;
+use std::fmt::Debug;
+
+use criterion::measurement::WallTime;
+use criterion::{criterion_group, criterion_main, BenchmarkGroup, Criterion};
+use num_traits::Bounded;
+
+use fastlanes::{Delta, FastLanes};
+
+fn delta(c: &mut Criterion) {
+    let mut group = c.benchmark_group("delta");
+    delta_typed::<u8>(&mut group);
+    delta_typed::<u16>(&mut group);
+    delta_typed::<u32>(&mut group);
+    delta_typed::<u64>(&mut group);
+}
+
+fn delta_typed<T: Delta + Bounded + Debug>(group: &mut BenchmarkGroup<WallTime>)
+where
+    [(); T::LANES]:,
+{
+    // We heap allocate the values to avoid Rust evaluating the Delta functions at compile time!
+    let mut values = Vec::with_capacity(1024);
+    for i in 0..1024 {
+        values.push(T::from(i % <T>::max_value().to_usize().unwrap()).unwrap());
+    }
+    let base: [T; <T as FastLanes>::LANES] = [T::zero(); <T as FastLanes>::LANES];
+    let mut output: [T; 1024] = [T::zero(); 1024];
+
+    group.bench_function(format!("delta encode {}", type_name::<T>()), |b| {
+        b.iter(|| Delta::encode(array_ref![values, 0, 1024], &base, &mut output));
+    });
+
+    group.bench_function(format!("delta decode {}", type_name::<T>()), |b| {
+        b.iter(|| Delta::decode(array_ref![values, 0, 1024], &base, &mut output));
+    });
+}
+
+criterion_group!(benches, delta);
+criterion_main!(benches);

--- a/benches/transpose.rs
+++ b/benches/transpose.rs
@@ -3,7 +3,7 @@
 
 use std::mem::size_of;
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main, Criterion};
 
 use fastlanes::{BitPacking, Transpose};
 

--- a/benches/transpose.rs
+++ b/benches/transpose.rs
@@ -1,0 +1,24 @@
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+
+use std::mem::size_of;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+
+use fastlanes::{BitPacking, Transpose};
+
+fn transpose(c: &mut Criterion) {
+    let mut group = c.benchmark_group("transpose");
+    group.bench_function("transpose u16", |b| {
+        let mut values: [u16; 1024] = [0; 1024];
+        for i in 0..1024 {
+            values[i] = (i % u16::MAX as usize) as u16;
+        }
+
+        let mut transposed = [0; 1024];
+        b.iter(|| Transpose::transpose(&values, &mut transposed));
+    });
+}
+
+criterion_group!(benches, transpose);
+criterion_main!(benches);

--- a/benches/transpose.rs
+++ b/benches/transpose.rs
@@ -1,11 +1,9 @@
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 
-use std::mem::size_of;
-
 use criterion::{criterion_group, criterion_main, Criterion};
 
-use fastlanes::{BitPacking, Transpose};
+use fastlanes::Transpose;
 
 fn transpose(c: &mut Criterion) {
     let mut group = c.benchmark_group("transpose");

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -1,0 +1,123 @@
+use crate::{seq_s, FastLanes, FL_ORDER};
+use paste::paste;
+use seq_macro::seq;
+
+pub trait Delta: FastLanes {
+    /// Delta-encode the input array. The input array should already be transposed.
+    fn encode(input: &[Self; 1024], base: &[Self; Self::LANES], output: &mut [Self; 1024]);
+
+    /// Delta-decode the input array. The output array will be in transposed order.
+    fn decode(input: &[Self; 1024], base: &[Self; Self::LANES], output: &mut [Self; 1024]);
+}
+
+macro_rules! impl_delta {
+    ($T:ty) => {
+        paste! {
+            impl Delta for $T {
+                #[allow(unused_assignments)]
+                #[inline(never)]
+                fn encode(input: &[Self; 1024], base: &[Self; Self::LANES], output: &mut [Self; 1024]) {
+                    for i in 0..Self::LANES {
+                        let mut prev = base[i];
+
+                        seq_s!(o in $T {
+                             seq!(row in 0..8 {
+                                let pos = (FL_ORDER[o] * 16) + (128 * row) + i;
+                                let next = input[pos];
+                                output[pos] = next.wrapping_sub(prev);
+                                prev = next;
+                            });
+                        });
+                    }
+                }
+
+                #[allow(unused_assignments)]
+                #[inline(never)]
+                fn decode(input: &[Self; 1024], base: &[Self; Self::LANES], output: &mut [Self; 1024]) {
+                    for i in 0..Self::LANES {
+                        let mut prev = base[i];
+
+                        seq_s!(o in $T {
+                             seq!(row in 0..8 {
+                                let pos = (FL_ORDER[o] * 16) + (128 * row) + i;
+                                let next = input[pos].wrapping_add(prev);
+                                output[pos] = next;
+                                prev = next;
+                            });
+                        });
+                    }
+                }
+            }
+        }
+    };
+}
+
+impl_delta!(u8);
+impl_delta!(u16);
+impl_delta!(u32);
+impl_delta!(u64);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::round_robin_values;
+    use crate::Transpose;
+    use std::fmt::Debug;
+
+    #[test]
+    fn test_delta() {
+        test_delta_typed::<u8>();
+        test_delta_typed::<u16>();
+        test_delta_typed::<u32>();
+        test_delta_typed::<u64>();
+    }
+
+    #[inline(never)]
+    fn test_delta_typed<T: Delta + Debug>()
+    where
+        [(); T::LANES]:,
+    {
+        let values: [T; 1024] = round_robin_values();
+
+        let mut input = [T::zero(); 1024];
+        Transpose::transpose(&values, &mut input);
+
+        // Encode with base of zeros
+        let base = [T::zero(); T::LANES];
+        let mut encoded = [T::zero(); 1024];
+        Delta::encode(&input, &base, &mut encoded);
+
+        let mut decoded = [T::zero(); 1024];
+        Delta::decode(&encoded, &base, &mut decoded);
+        assert_eq!(input, decoded);
+
+        let mut decoded_values = [T::zero(); 1024];
+        Transpose::untranspose(&decoded, &mut decoded_values);
+        assert_eq!(values, decoded_values);
+    }
+
+    #[test]
+    fn delta_non_increasing() {
+        test_delta_non_increasing::<u8>();
+        test_delta_non_increasing::<u16>();
+        test_delta_non_increasing::<u32>();
+        test_delta_non_increasing::<u64>();
+    }
+
+    fn test_delta_non_increasing<T: Delta + Debug>()
+    where
+        [(); T::LANES]:,
+    {
+        // We skip transposing such that the values aren't necessarily increasing
+        let values: [T; 1024] = round_robin_values::<T>();
+
+        // Encode with base of zeros
+        let base = [T::zero(); T::LANES];
+        let mut encoded = [T::zero(); 1024];
+        Delta::encode(&values, &base, &mut encoded);
+
+        let mut decoded = [T::zero(); 1024];
+        Delta::decode(&encoded, &base, &mut decoded);
+        assert_eq!(values, decoded);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,12 @@ use std::mem::size_of;
 use num_traits::{PrimInt, Unsigned};
 
 mod bitpacking;
-pub use bitpacking::*;
+mod transpose;
 
-pub const ORDER: [u8; 8] = [0, 4, 2, 6, 1, 5, 3, 7];
+pub use bitpacking::*;
+pub use transpose::*;
+
+pub const FL_ORDER: [u8; 8] = [0, 4, 2, 6, 1, 5, 3, 7];
 
 pub trait FastLanes: Sized + Unsigned + PrimInt {
     const T: usize = size_of::<Self>() * 8;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,14 @@ use std::mem::size_of;
 use num_traits::{PrimInt, Unsigned};
 
 mod bitpacking;
+mod delta;
 mod transpose;
 
 pub use bitpacking::*;
+pub use delta::*;
 pub use transpose::*;
 
-pub const FL_ORDER: [u8; 8] = [0, 4, 2, 6, 1, 5, 3, 7];
+pub const FL_ORDER: [usize; 8] = [0, 4, 2, 6, 1, 5, 3, 7];
 
 pub trait FastLanes: Sized + Unsigned + PrimInt {
     const T: usize = size_of::<Self>() * 8;
@@ -28,3 +30,34 @@ pub struct Pred<const B: bool>;
 pub trait Satisfied {}
 
 impl Satisfied for Pred<true> {}
+
+// Macro for repeating a code block bit_size_of::<T> times.
+macro_rules! seq_t {
+    ($ident:ident in u8 $body:tt) => {seq!($ident in 0..8 $body);};
+    ($ident:ident in u16 $body:tt) => {seq!($ident in 0..16 $body);};
+    ($ident:ident in u32 $body:tt) => {seq!($ident in 0..32 $body);};
+    ($ident:ident in u64 $body:tt) => {seq!($ident in 0..64 $body);};
+}
+pub(crate) use seq_t;
+
+// Macro for repeating a code block size_of::<T> times.
+macro_rules! seq_s {
+    ($ident:ident in u8 $body:tt) => {seq!($ident in 0..1 $body);};
+    ($ident:ident in u16 $body:tt) => {seq!($ident in 0..2 $body);};
+    ($ident:ident in u32 $body:tt) => {seq!($ident in 0..4 $body);};
+    ($ident:ident in u64 $body:tt) => {seq!($ident in 0..8 $body);};
+}
+pub(crate) use seq_s;
+
+#[cfg(test)]
+mod test {
+    use crate::FastLanes;
+
+    pub(crate) fn round_robin_values<T: FastLanes>() -> [T; 1024] {
+        let mut values = [T::zero(); 1024];
+        for i in 0..1024 {
+            values[i] = T::from(i % T::max_value().to_usize().unwrap()).unwrap();
+        }
+        values
+    }
+}

--- a/src/transpose.rs
+++ b/src/transpose.rs
@@ -1,5 +1,5 @@
-use seq_macro::seq;
 use crate::{FastLanes, FL_ORDER};
+use seq_macro::seq;
 
 pub trait Transpose: FastLanes {
     const MASK: [usize; 1024] = transpose_mask();
@@ -9,7 +9,10 @@ pub trait Transpose: FastLanes {
     fn untranspose(input: &[Self; 1024], output: &mut [Self; 1024]);
 }
 
-impl<T> Transpose for T where T: FastLanes {
+impl<T> Transpose for T
+where
+    T: FastLanes,
+{
     #[inline(never)]
     fn transpose(input: &[Self; 1024], output: &mut [Self; 1024]) {
         seq!(i in 0..1024 {

--- a/src/transpose.rs
+++ b/src/transpose.rs
@@ -1,0 +1,57 @@
+use seq_macro::seq;
+use crate::{FastLanes, FL_ORDER};
+
+pub trait Transpose: FastLanes {
+    const MASK: [usize; 1024] = transpose_mask();
+    const UNMASK: [usize; 1024] = untranspose_mask();
+
+    fn transpose(input: &[Self; 1024], output: &mut [Self; 1024]);
+    fn untranspose(input: &[Self; 1024], output: &mut [Self; 1024]);
+}
+
+impl<T> Transpose for T where T: FastLanes {
+    #[inline(never)]
+    fn transpose(input: &[Self; 1024], output: &mut [Self; 1024]) {
+        seq!(i in 0..1024 {
+            unsafe { *output.get_unchecked_mut(i) = *input.get_unchecked(Self::MASK[i]) };
+        });
+    }
+
+    #[inline(never)]
+    fn untranspose(input: &[Self; 1024], output: &mut [Self; 1024]) {
+        seq!(i in 0..1024 {
+            unsafe { *output.get_unchecked_mut(i) = *input.get_unchecked(Self::UNMASK[i]) };
+        });
+    }
+}
+
+const fn transpose_mask() -> [usize; 1024] {
+    let mut mask = [0; 1024];
+    let mut mask_idx = 0;
+    let mut row = 0;
+    while row < 8 {
+        let mut order = 0;
+        while order < FL_ORDER.len() {
+            let mut lane = 0;
+            while lane < 16 {
+                mask[mask_idx] = (lane * 64) + (FL_ORDER[order] as usize * 8) + row;
+                mask_idx += 1;
+                lane += 1;
+            }
+            order += 1;
+        }
+        row += 1;
+    }
+    mask
+}
+
+const fn untranspose_mask() -> [usize; 1024] {
+    const MASK: [usize; 1024] = transpose_mask();
+    let mut mask = [0; 1024];
+    let mut mask_idx = 0;
+    while mask_idx < 1024 {
+        mask[mask_idx] = MASK[mask_idx];
+        mask_idx += 1;
+    }
+    mask
+}

--- a/src/transpose.rs
+++ b/src/transpose.rs
@@ -13,14 +13,14 @@ impl<T> Transpose for T where T: FastLanes {
     #[inline(never)]
     fn transpose(input: &[Self; 1024], output: &mut [Self; 1024]) {
         seq!(i in 0..1024 {
-            unsafe { *output.get_unchecked_mut(i) = *input.get_unchecked(Self::MASK[i]) };
+            output[i] = input[Self::MASK[i]];
         });
     }
 
     #[inline(never)]
     fn untranspose(input: &[Self; 1024], output: &mut [Self; 1024]) {
         seq!(i in 0..1024 {
-            unsafe { *output.get_unchecked_mut(i) = *input.get_unchecked(Self::UNMASK[i]) };
+            output[i] = input[Self::UNMASK[i]];
         });
     }
 }

--- a/src/transpose.rs
+++ b/src/transpose.rs
@@ -2,59 +2,32 @@ use crate::{FastLanes, FL_ORDER};
 use seq_macro::seq;
 
 pub trait Transpose: FastLanes {
-    const MASK: [usize; 1024] = transpose_mask();
-    const UNMASK: [usize; 1024] = untranspose_mask();
-
     fn transpose(input: &[Self; 1024], output: &mut [Self; 1024]);
     fn untranspose(input: &[Self; 1024], output: &mut [Self; 1024]);
 }
 
-impl<T> Transpose for T
-where
-    T: FastLanes,
-{
+impl<T: FastLanes> Transpose for T {
     #[inline(never)]
     fn transpose(input: &[Self; 1024], output: &mut [Self; 1024]) {
         seq!(i in 0..1024 {
-            output[i] = input[Self::MASK[i]];
+            output[i] = input[mask(i)];
         });
     }
 
     #[inline(never)]
     fn untranspose(input: &[Self; 1024], output: &mut [Self; 1024]) {
         seq!(i in 0..1024 {
-            output[i] = input[Self::UNMASK[i]];
+            output[mask(i)] = input[i];
         });
     }
 }
 
-const fn transpose_mask() -> [usize; 1024] {
-    let mut mask = [0; 1024];
-    let mut mask_idx = 0;
-    let mut row = 0;
-    while row < 8 {
-        let mut order = 0;
-        while order < FL_ORDER.len() {
-            let mut lane = 0;
-            while lane < 16 {
-                mask[mask_idx] = (lane * 64) + (FL_ORDER[order] as usize * 8) + row;
-                mask_idx += 1;
-                lane += 1;
-            }
-            order += 1;
-        }
-        row += 1;
-    }
-    mask
-}
+#[inline(always)]
+const fn mask(idx: usize) -> usize {
+    // Row * 8, ORDER * 8, lane * 16.
+    let lane = idx % 16;
+    let order = (idx / 16) % 8;
+    let row = idx / 128;
 
-const fn untranspose_mask() -> [usize; 1024] {
-    const MASK: [usize; 1024] = transpose_mask();
-    let mut mask = [0; 1024];
-    let mut mask_idx = 0;
-    while mask_idx < 1024 {
-        mask[mask_idx] = MASK[mask_idx];
-        mask_idx += 1;
-    }
-    mask
+    (lane * 64) + (FL_ORDER[order] * 8) + row
 }


### PR DESCRIPTION
Fixes #10 

We may want to abstract away the transposed iteration ordering inside a seq macro, but I'll leave that until we run into it a few times. It could help make it almost trivial to implement new fused kernels.