### PR TITLE
feat: Use stable Rust edition 2021

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -21,7 +21,7 @@ runs:
       with:
         toolchain: "${{ steps.rust-version.outputs.version }}"
         targets: "${{inputs.targets || ''}}"
-        components: clippy, rustfmt, miri, llvm-tools-preview
+        components: clippy, rustfmt
 
     - name: Rust Dependency Cache
       uses: Swatinem/rust-cache@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/spiraldb/fastlanes"
 repository = "https://github.com/spiraldb/fastlanes"
 authors = ["SpiralDB <hello@spiraldb.com>"]
 keywords = ["fastlanes", "compression", "codec"]
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 arrayref = "0.3.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ seq-macro = "0.3.5"
 
 [dev-dependencies]
 arrayref = "0.3.7"
-criterion = { package = "codspeed-criterion-compat", version = "2.8" }
-divan = { package = "codspeed-divan-compat", version = "2.8" }
+criterion = { package = "codspeed-criterion-compat", version = "3.0" }
+divan = { package = "codspeed-divan-compat", version = "3.0" }
 
 [lints.rust]
 warnings = "deny"

--- a/benches/bitpacking.rs
+++ b/benches/bitpacking.rs
@@ -1,32 +1,32 @@
-#![allow(incomplete_features)]
-#![feature(generic_const_exprs)]
-
 use std::mem::size_of;
 
 use arrayref::{array_mut_ref, array_ref};
-use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
-use fastlanes::BitPacking;
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use fastlanes::{BitPacking, FastLanes};
 
 fn pack(c: &mut Criterion) {
     {
         let mut group = c.benchmark_group("pack");
         group.bench_function("pack 16 -> 3 heap", |b| {
             const WIDTH: usize = 3;
+            const B: usize = 1024 * WIDTH / u16::T;
             let values = vec![3u16; 1024];
             let mut packed = vec![0; 128 * WIDTH / size_of::<u16>()];
 
             b.iter(|| {
-                BitPacking::pack::<WIDTH>(black_box(array_ref![values, 0, 1024]), array_mut_ref![
-                    packed, 0, 192
-                ]);
+                BitPacking::pack::<WIDTH, B>(
+                    black_box(array_ref![values, 0, 1024]),
+                    array_mut_ref![packed, 0, 192],
+                );
             });
         });
 
         group.bench_function("pack 16 -> 3 stack", |b| {
             const WIDTH: usize = 3;
+            const B: usize = 1024 * WIDTH / u16::T;
             let values = [3u16; 1024];
             let mut packed = [0; 128 * WIDTH / size_of::<u16>()];
-            b.iter(|| BitPacking::pack::<WIDTH>(black_box(&values), &mut packed));
+            b.iter(|| BitPacking::pack::<WIDTH, B>(black_box(&values), &mut packed));
         });
     }
 
@@ -34,13 +34,14 @@ fn pack(c: &mut Criterion) {
         let mut group = c.benchmark_group("unpack");
         group.bench_function("unpack 16 <- 3 stack", |b| {
             const WIDTH: usize = 3;
+            const B: usize = 1024 * WIDTH / u16::T;
             let values = [3u16; 1024];
             let mut packed = [0; 128 * WIDTH / size_of::<u16>()];
-            BitPacking::pack::<WIDTH>(&values, &mut packed);
+            BitPacking::pack::<WIDTH, B>(&values, &mut packed);
 
             let mut unpacked = [0u16; 1024];
             b.iter(|| {
-                BitPacking::unpack::<WIDTH>(&black_box(packed), &mut unpacked);
+                BitPacking::unpack::<WIDTH, B>(&black_box(packed), &mut unpacked);
                 let _ = black_box(unpacked);
             });
         });
@@ -50,9 +51,10 @@ fn pack(c: &mut Criterion) {
         let mut group = c.benchmark_group("unpack");
         group.bench_function("unchecked unpack 16 <- 3 stack", |b| {
             const WIDTH: usize = 3;
+            const B: usize = 1024 * WIDTH / u16::T;
             let values = [3u16; 1024];
             let mut packed = [0; 128 * WIDTH / size_of::<u16>()];
-            BitPacking::pack::<WIDTH>(&values, &mut packed);
+            BitPacking::pack::<WIDTH, B>(&values, &mut packed);
 
             let mut unpacked = [0u16; 1024];
             b.iter(|| {
@@ -66,13 +68,17 @@ fn pack(c: &mut Criterion) {
         let mut group = c.benchmark_group("unpack-single");
         group.bench_function("unpack single 16 <- 3", |b| {
             const WIDTH: usize = 3;
+            const B: usize = 1024 * WIDTH / u16::T;
             let values = vec![3u16; 1024];
             let mut packed = vec![0; 128 * WIDTH / size_of::<u16>()];
-            BitPacking::pack::<WIDTH>(array_ref![values, 0, 1024], array_mut_ref![packed, 0, 192]);
+            BitPacking::pack::<WIDTH, B>(
+                array_ref![values, 0, 1024],
+                array_mut_ref![packed, 0, 192],
+            );
 
             b.iter(|| {
                 for i in 0..1024 {
-                    black_box::<u16>(BitPacking::unpack_single::<WIDTH>(
+                    black_box::<u16>(BitPacking::unpack_single::<WIDTH, B>(
                         black_box(array_ref![packed, 0, 192]),
                         i,
                     ));
@@ -84,6 +90,7 @@ fn pack(c: &mut Criterion) {
 
 fn throughput(c: &mut Criterion) {
     const WIDTH: usize = 3;
+    const B: usize = 1024 * WIDTH / u16::T;
     const NUM_BATCHES: usize = 1024;
     const N: usize = 1024 * NUM_BATCHES;
     const OUTPUT_BATCH_SIZE: usize = 128 * WIDTH / size_of::<u16>();
@@ -96,7 +103,7 @@ fn throughput(c: &mut Criterion) {
     group.bench_function("compress", |b| {
         b.iter(|| {
             for i in 0..NUM_BATCHES {
-                BitPacking::pack::<WIDTH>(
+                BitPacking::pack::<WIDTH, B>(
                     black_box(array_ref![values, i * 1024, 1024]),
                     array_mut_ref![packed, i * OUTPUT_BATCH_SIZE, OUTPUT_BATCH_SIZE],
                 );
@@ -107,7 +114,7 @@ fn throughput(c: &mut Criterion) {
     group.bench_function("decompress", |b| {
         b.iter(|| {
             for i in 0..NUM_BATCHES {
-                BitPacking::unpack::<WIDTH>(
+                BitPacking::unpack::<WIDTH, B>(
                     black_box(array_ref![packed, i * OUTPUT_BATCH_SIZE, OUTPUT_BATCH_SIZE]),
                     array_mut_ref![values, i * 1024, 1024],
                 );

--- a/benches/bitpacking_cmp.rs
+++ b/benches/bitpacking_cmp.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![allow(unexpected_cfgs)]
 
 fn main() {

--- a/benches/bitpacking_cmp.rs
+++ b/benches/bitpacking_cmp.rs
@@ -1,5 +1,4 @@
 #![allow(incomplete_features)]
-#![feature(generic_const_exprs)]
 #![allow(unexpected_cfgs)]
 
 fn main() {
@@ -20,11 +19,10 @@ mod bench {
     where
         T: BitPacking + FastLanesComparable<Bitpacked = T> + FromPrimitive + Copy,
         T: BitPacking + BitPackingCompare + Copy,
-        [(); 128 * W / size_of::<T>()]:,
     {
         let value = T::from_usize(1).expect("");
         let values = [T::from_usize(2).expect(""); 1024];
-        let mut packed = [T::zero(); 128 * W / size_of::<T>()];
+        let mut packed = vec![T::zero(); 128 * W / size_of::<T>()];
 
         unsafe { BitPacking::unchecked_pack(W, &values, &mut packed) };
 
@@ -48,11 +46,10 @@ mod bench {
     fn bitpacking_cmp_seq<T, const W: usize>(bencher: Bencher)
     where
         T: BitPacking + FromPrimitive + Copy,
-        [(); 128 * W / size_of::<T>()]:,
     {
         let value = T::from_usize(1).expect("");
         let values = [T::from_usize(2).expect(""); 1024];
-        let mut packed = [T::zero(); 128 * W / size_of::<T>()];
+        let mut packed = vec![T::zero(); 128 * W / size_of::<T>()];
 
         unsafe { T::unchecked_pack(W, &values, &mut packed) };
 
@@ -70,10 +67,9 @@ mod bench {
     fn bitpacking_cmp_unpack<T, const W: usize>(bencher: Bencher)
     where
         T: BitPacking + FromPrimitive + Copy,
-        [(); 128 * W / size_of::<T>()]:,
     {
         let values = [T::from_usize(2).expect(""); 1024];
-        let mut packed = [T::zero(); 128 * W / size_of::<T>()];
+        let mut packed = vec![T::zero(); 128 * W / size_of::<T>()];
 
         unsafe { T::unchecked_pack(W, &values, &mut packed) };
 

--- a/benches/bitpacking_cmp_cod.rs
+++ b/benches/bitpacking_cmp_cod.rs
@@ -1,6 +1,3 @@
-#![allow(incomplete_features)]
-#![feature(generic_const_exprs)]
-
 // TODO(joe): remove this once codspeed supports const generics.
 
 use divan::Bencher;
@@ -14,14 +11,13 @@ fn main() {
 #[divan::bench(types=[u16, u32, u64])]
 fn bitpacking_cmp_fused<T>(bencher: Bencher)
 where
-    [(); 128 * 3 / size_of::<T>()]:,
     T: BitPacking + FastLanesComparable<Bitpacked = T> + FromPrimitive + Copy,
     T::Bitpacked: BitPacking + BitPackingCompare + Copy,
 {
     const W: usize = 3;
     let value = T::from_usize(1).expect("");
     let values = [T::from_usize(2).expect(""); 1024];
-    let mut packed = [T::zero(); 128 * 3 / size_of::<T>()];
+    let mut packed = vec![T::zero(); 128 * 3 / size_of::<T>()];
 
     unsafe { BitPacking::unchecked_pack(W, &values, &mut packed) };
 
@@ -41,14 +37,11 @@ where
 }
 
 #[divan::bench(types=[u16, u32, u64])]
-fn bitpacking_cmp_seq<T: BitPacking + FromPrimitive + Copy>(bencher: Bencher)
-where
-    [(); 128 * 3 / size_of::<T>()]:,
-{
+fn bitpacking_cmp_seq<T: BitPacking + FromPrimitive + Copy>(bencher: Bencher) {
     const W: usize = 3;
     let value = T::from_usize(1).expect("");
     let values = [T::from_usize(2).expect(""); 1024];
-    let mut packed = [T::zero(); 128 * 3 / size_of::<T>()];
+    let mut packed = vec![T::zero(); 128 * 3 / size_of::<T>()];
 
     unsafe { T::unchecked_pack(W, &values, &mut packed) };
 
@@ -61,13 +54,10 @@ where
 }
 
 #[divan::bench(types=[u16, u32, u64])]
-fn bitpacking_cmp_unpack<T: BitPacking + FromPrimitive + Copy>(bencher: Bencher)
-where
-    [(); 128 * 3 / size_of::<T>()]:,
-{
+fn bitpacking_cmp_unpack<T: BitPacking + FromPrimitive + Copy>(bencher: Bencher) {
     const W: usize = 3;
     let values = [T::from_usize(2).expect(""); 1024];
-    let mut packed = [T::zero(); 128 * W / size_of::<T>()];
+    let mut packed = vec![T::zero(); 128 * W / size_of::<T>()];
 
     unsafe { T::unchecked_pack(W, &values, &mut packed) };
 

--- a/benches/delta.rs
+++ b/benches/delta.rs
@@ -1,14 +1,13 @@
-#![allow(incomplete_features)]
-#![feature(generic_const_exprs)]
-
 use arrayref::{array_mut_ref, array_ref};
-use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use std::mem::size_of;
 
-use fastlanes::{BitPacking, Delta, Transpose};
+use fastlanes::{BitPacking, Delta, FastLanes, Transpose};
 
 fn delta(c: &mut Criterion) {
     const W: usize = 9;
+    const B: usize = 1024 * W / <u16 as FastLanes>::T;
+    const LANES: usize = u16::LANES;
 
     let mut group = c.benchmark_group("delta");
     group.throughput(Throughput::Bytes(1024 * size_of::<u16>() as u64));
@@ -24,19 +23,19 @@ fn delta(c: &mut Criterion) {
     Delta::delta(&transposed, &[0; 64], &mut deltas);
 
     let mut packed = [0; 128 * W / size_of::<u16>()];
-    BitPacking::pack::<W>(&deltas, &mut packed);
+    BitPacking::pack::<W, B>(&deltas, &mut packed);
 
     group.bench_function("delta u16 fused", |b| {
         b.iter(|| {
             let mut unpacked = [0; 1024];
-            Delta::undelta_pack::<W>(&packed, &[0; 64], &mut unpacked);
+            Delta::undelta_pack::<LANES, W, B>(&packed, &[0; 64], &mut unpacked);
         });
     });
 
     group.bench_function("delta u16 unfused", |b| {
         b.iter(|| {
             let mut unpacked = [0; 1024];
-            BitPacking::unpack::<W>(&packed, &mut unpacked);
+            BitPacking::unpack::<W, B>(&packed, &mut unpacked);
             let mut undelta = [0; 1024];
             Delta::undelta(&unpacked, &[0; 64], &mut undelta);
         });
@@ -45,6 +44,7 @@ fn delta(c: &mut Criterion) {
 
 fn throughput(c: &mut Criterion) {
     const WIDTH: usize = 3;
+    const B: usize = 1024 * WIDTH / u16::T;
     const NUM_BATCHES: usize = 1024;
     const N: usize = 1024 * NUM_BATCHES;
     const OUTPUT_BATCH_SIZE: usize = 128 * WIDTH / size_of::<u16>();
@@ -57,11 +57,10 @@ fn throughput(c: &mut Criterion) {
     group.bench_function("compress", |b| {
         b.iter(|| {
             for i in 0..NUM_BATCHES {
-                BitPacking::pack::<WIDTH>(array_ref![values, i * 1024, 1024], array_mut_ref![
-                    packed,
-                    i * OUTPUT_BATCH_SIZE,
-                    OUTPUT_BATCH_SIZE
-                ]);
+                BitPacking::pack::<WIDTH, B>(
+                    array_ref![values, i * 1024, 1024],
+                    array_mut_ref![packed, i * OUTPUT_BATCH_SIZE, OUTPUT_BATCH_SIZE],
+                );
             }
         });
     });
@@ -69,7 +68,7 @@ fn throughput(c: &mut Criterion) {
     group.bench_function("decompress", |b| {
         b.iter(|| {
             for i in 0..NUM_BATCHES {
-                BitPacking::unpack::<WIDTH>(
+                BitPacking::unpack::<WIDTH, B>(
                     array_ref![packed, i * OUTPUT_BATCH_SIZE, OUTPUT_BATCH_SIZE],
                     array_mut_ref![values, i * 1024, 1024],
                 );

--- a/benches/transpose.rs
+++ b/benches/transpose.rs
@@ -1,7 +1,4 @@
-#![allow(incomplete_features)]
-#![feature(generic_const_exprs)]
-
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main, Criterion};
 
 use fastlanes::Transpose;
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-12-25"
+channel = "1.88.0"
 components = ["rust-src", "rustfmt", "clippy"]
 profile = "minimal"

--- a/src/bitpacking.rs
+++ b/src/bitpacking.rs
@@ -3,22 +3,14 @@ use const_for::const_for;
 use core::mem::size_of;
 use paste::paste;
 
-use crate::{FL_ORDER, FastLanes, Pred, Satisfied, pack, seq_t, unpack};
+use crate::{pack, seq_t, unpack, FastLanes, FL_ORDER, supported_bit_width};
 
-pub struct BitPackWidth<const W: usize>;
-pub trait SupportedBitPackWidth<T> {}
-impl<const W: usize, T> SupportedBitPackWidth<T> for BitPackWidth<W> where
-    Pred<{ W <= 8 * size_of::<T>() }>: Satisfied
-{
-}
 
 /// `BitPack` into a compile-time known bit-width.
 pub trait BitPacking: FastLanes {
     /// Packs 1024 elements into W bits each.
     /// The output is given as Self to ensure correct alignment.
-    fn pack<const W: usize>(input: &[Self; 1024], output: &mut [Self; 1024 * W / Self::T])
-    where
-        BitPackWidth<W>: SupportedBitPackWidth<Self>;
+    fn pack<const W: usize, const B: usize>(input: &[Self; 1024], output: &mut [Self; B]);
 
     /// Packs 1024 elements into `W` bits each, where `W` is runtime-known instead of
     /// compile-time known.
@@ -30,9 +22,7 @@ pub trait BitPacking: FastLanes {
     unsafe fn unchecked_pack(width: usize, input: &[Self], output: &mut [Self]);
 
     /// Unpacks 1024 elements from `W` bits each.
-    fn unpack<const W: usize>(input: &[Self; 1024 * W / Self::T], output: &mut [Self; 1024])
-    where
-        BitPackWidth<W>: SupportedBitPackWidth<Self>;
+    fn unpack<const W: usize, const B: usize>(input: &[Self; B], output: &mut [Self; 1024]);
 
     /// Unpacks 1024 elements from `W` bits each, where `W` is runtime-known instead of
     /// compile-time known.
@@ -44,9 +34,7 @@ pub trait BitPacking: FastLanes {
     unsafe fn unchecked_unpack(width: usize, input: &[Self], output: &mut [Self]);
 
     /// Unpacks a single element at the provided index from a packed array of 1024 `W` bit elements.
-    fn unpack_single<const W: usize>(packed: &[Self; 1024 * W / Self::T], index: usize) -> Self
-    where
-        BitPackWidth<W>: SupportedBitPackWidth<Self>;
+    fn unpack_single<const W: usize, const B: usize>(packed: &[Self; B], index: usize) -> Self;
 
     /// Unpacks a single element at the provided index from a packed array of 1024 `W` bit elements,
     /// where `W` is runtime-known instead of compile-time known.
@@ -63,10 +51,16 @@ macro_rules! impl_packing {
         paste! {
             impl BitPacking for $T {
                 #[inline(never)]
-                fn pack<const W: usize>(
+                fn pack<const W: usize, const B: usize>(
                     input: &[Self; 1024],
-                    output: &mut [Self; 1024 * W / Self::T],
-                ) where BitPackWidth<W>: SupportedBitPackWidth<Self> {
+                    output: &mut [Self; B],
+                ) {
+                    const {
+                        assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
+                        assert!(B == 1024 * W / Self::T);
+                    }
+
+
                     for lane in 0..Self::LANES {
                         pack!($T, W, output, lane, |$idx| {
                             input[$idx]
@@ -82,25 +76,39 @@ macro_rules! impl_packing {
 
                     seq_t!(W in $T {
                         match width {
-                            #(W => Self::pack::<W>(
-                                array_ref![input, 0, 1024],
-                                array_mut_ref![output, 0, 1024 * W / <$T>::T],
-                            ),)*
+                            #(W => {
+                                const B: usize = 1024 * W / <$T>::T;
+                                Self::pack::<W, B>(
+                                    array_ref![input, 0, 1024],
+                                    array_mut_ref![output, 0, B],
+                                )
+                            },)*
                             // seq_t has exclusive upper bound
-                            Self::T => Self::pack::<{ Self::T }>(
-                                array_ref![input, 0, 1024],
-                                array_mut_ref![output, 0, 1024],
-                            ),
+                            Self::T => {
+                                // How large is the target buffer size?
+                                const W: usize = <$T>::T;
+                                const B: usize = 1024;
+                                Self::pack::<W, B>(
+                                    array_ref![input, 0, 1024],
+                                    array_mut_ref![output, 0, 1024],
+                                )
+                            },
                             _ => unreachable!("Unsupported width: {}", width)
                         }
                     })
                 }
 
                 #[inline(never)]
-                fn unpack<const W: usize>(
-                    input: &[Self; 1024 * W / Self::T],
+                fn unpack<const W: usize, const B: usize>(
+                    input: &[Self; B],
                     output: &mut [Self; 1024],
-                ) where BitPackWidth<W>: SupportedBitPackWidth<Self> {
+                ) {
+                    const {
+                        assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
+                        assert!(B == 1024 * W / Self::T);
+                    }
+
+
                     for lane in 0..Self::LANES {
                         unpack!($T, W, input, lane, |$idx, $elem| {
                             output[$idx] = $elem
@@ -116,25 +124,35 @@ macro_rules! impl_packing {
 
                     seq_t!(W in $T {
                         match width {
-                            #(W => Self::unpack::<W>(
-                                array_ref![input, 0, 1024 * W / <$T>::T],
-                                array_mut_ref![output, 0, 1024],
-                            ),)*
+                            #(W => {
+                                const B: usize = 1024 * W / <$T>::T;
+                                Self::unpack::<W, B>(
+                                    array_ref![input, 0, B],
+                                    array_mut_ref![output, 0, 1024],
+                                )
+                            },)*
                             // seq_t has exclusive upper bound
-                            Self::T => Self::unpack::<{ Self::T }>(
-                                array_ref![input, 0, 1024],
-                                array_mut_ref![output, 0, 1024],
-                            ),
+                            Self::T => {
+                                const W: usize = <$T>::T;
+                                const B: usize = 1024;
+                                Self::unpack::<W, B>(
+                                    array_ref![input, 0, 1024],
+                                    array_mut_ref![output, 0, 1024],
+                                )
+                            },
                             _ => unreachable!("Unsupported width: {}", width)
                         }
                     })
                 }
 
                 /// Unpacks a single element at the provided index from a packed array of 1024 `W` bit elements.
-                fn unpack_single<const W: usize>(packed: &[Self; 1024 * W / Self::T], index: usize) -> Self
-                where
-                    BitPackWidth<W>: SupportedBitPackWidth<Self>,
+                fn unpack_single<const W: usize, const B: usize>(packed: &[Self; B], index: usize) -> Self
                 {
+                    const {
+                        assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
+                        assert!(B == 1024 * W / Self::T);
+                    }
+
                     if W == 0 {
                         // Special case for W=0, we just need to zero the output.
                         return 0 as $T;
@@ -190,11 +208,14 @@ macro_rules! impl_packing {
                     seq_t!(W in $T {
                         match width {
                             #(W => {
-                                return <$T>::unpack_single::<W>(array_ref![packed, 0, 1024 * W / T], index);
+                                const B: usize = 1024 * W / T;
+                                return <$T>::unpack_single::<W, B>(array_ref![packed, 0, B], index);
                             },)*
                             // seq_t has exclusive upper bound
                             T => {
-                                return <$T>::unpack_single::<T>(array_ref![packed, 0, 1024], index);
+                                const W: usize = T;
+                                const B: usize = 1024;
+                                return <$T>::unpack_single::<W, B>(array_ref![packed, 0, 1024], index);
                             },
                             _ => unreachable!("Unsupported width: {}", width)
                         }
@@ -242,7 +263,6 @@ impl_packing!(u64);
 mod test {
     use core::array;
     use core::fmt::Debug;
-    use core::mem::size_of;
     use seq_macro::seq;
 
     use super::*;
@@ -261,10 +281,10 @@ mod test {
     fn test_unpack_single() {
         let values = array::from_fn(|i| i as u32);
         let mut packed = [0; 512];
-        BitPacking::pack::<16>(&values, &mut packed);
+        BitPacking::pack::<16, 512>(&values, &mut packed);
 
         for i in 0..1024 {
-            assert_eq!(BitPacking::unpack_single::<16>(&packed, i), values[i]);
+            assert_eq!(BitPacking::unpack_single::<16, 512>(&packed, i), values[i]);
             assert_eq!(
                 unsafe { BitPacking::unchecked_unpack_single(16, &packed, i) },
                 values[i]
@@ -272,27 +292,22 @@ mod test {
         }
     }
 
-    fn try_round_trip<T: BitPacking + Debug, const W: usize>()
-    where
-        BitPackWidth<W>: SupportedBitPackWidth<T>,
-        [(); 128 * W / size_of::<T>()]:,
-        [(); 1024 * W / T::T]:,
-    {
+    fn try_round_trip<T: BitPacking + Debug, const W: usize, const B: usize>() {
         let mut values: [T; 1024] = [T::zero(); 1024];
         for i in 0..1024 {
             values[i] = T::from(i % (1 << (W % T::T))).unwrap();
         }
 
-        let mut packed = [T::zero(); 1024 * W / T::T];
-        BitPacking::pack::<W>(&values, &mut packed);
+        let mut packed = [T::zero(); B];
+        BitPacking::pack::<W, B>(&values, &mut packed);
 
         let mut unpacked = [T::zero(); 1024];
-        BitPacking::unpack::<W>(&packed, &mut unpacked);
+        BitPacking::unpack::<W, B>(&packed, &mut unpacked);
 
         assert_eq!(&unpacked, &values);
 
         for i in 0..1024 {
-            assert_eq!(BitPacking::unpack_single::<W>(&packed, i), values[i]);
+            assert_eq!(BitPacking::unpack_single::<W, B>(&packed, i), values[i]);
             assert_eq!(
                 unsafe { BitPacking::unchecked_unpack_single(W, &packed, i) },
                 values[i]
@@ -305,7 +320,8 @@ mod test {
             paste! {
                 #[test]
                 fn [<test_round_trip_ $T _ $W>]() {
-                    try_round_trip::<$T, $W>();
+                    const B: usize = 1024 * $W / <$T>::T;
+                    try_round_trip::<$T, $W, B>();
                 }
             }
         };

--- a/src/bitpacking.rs
+++ b/src/bitpacking.rs
@@ -3,8 +3,7 @@ use const_for::const_for;
 use core::mem::size_of;
 use paste::paste;
 
-use crate::{pack, seq_t, unpack, FastLanes, FL_ORDER, supported_bit_width};
-
+use crate::{pack, seq_t, supported_bit_width, unpack, FastLanes, FL_ORDER};
 
 /// `BitPack` into a compile-time known bit-width.
 pub trait BitPacking: FastLanes {

--- a/src/bitpacking_cmp.rs
+++ b/src/bitpacking_cmp.rs
@@ -1,21 +1,18 @@
-use crate::{BitPackWidth, SupportedBitPackWidth};
-use crate::{FastLanes, FastLanesComparable};
+use crate::{FastLanes, FastLanesComparable, supported_bit_width};
 
 pub trait BitPackingCompare: FastLanes {
     /// A fused unpack (see `BitPacking::unpack`) and compare and pack into bit bools.
     /// This will compare using the comparison function all the packed values with a constant value,
     /// the values are of type `Self`, whereas the comparison is on the type `V` (where `V::Bitpacked` = `Self`).
     /// This allows for comparison between signed values which are bitpacked as unsigned ones.
-    fn unpack_cmp<const W: usize, V, F>(
-        input: &[Self; 1024 * W / Self::T],
+    fn unpack_cmp<const W: usize, const B: usize, V, F>(
+        input: &[Self; B],
         output: &mut [bool; 1024],
         comparison: F,
         value: V,
     ) where
-        BitPackWidth<W>: SupportedBitPackWidth<Self>,
         V: FastLanesComparable<Bitpacked = Self>,
-        F: Fn(V, V) -> bool,
-        [(); 1024 / Self::T]:;
+        F: Fn(V, V) -> bool;
 
     /// A fused unpack (see `BitPacking::unpack`) and compare and pack into bit bools.
     ///
@@ -39,17 +36,21 @@ macro_rules! impl_packing_compare {
         paste::paste! {
             impl BitPackingCompare for $T {
                 #[inline(never)]
-                fn unpack_cmp<const W: usize, V, F>(
-                    input: &[Self; 1024 * W / Self::T],
+                fn unpack_cmp<const W: usize, const B: usize, V, F>(
+                    input: &[Self; B],
                     output: &mut [bool; 1024],
                     f: F,
                     other: V,
                 )
                 where
-                    BitPackWidth<W>: SupportedBitPackWidth<Self>,
                     V: FastLanesComparable<Bitpacked = Self>,
                     F: Fn(V, V) -> bool
                 {
+                    const {
+                        assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
+                        assert!(B == 1024 * W / Self::T);
+                    }
+
                     for lane in (0..Self::LANES) {
                         $crate::unpack!($T, W, input, lane, |$idx, $elem| {
                             output[$idx] = f(V::as_unpacked($elem), other);
@@ -74,12 +75,15 @@ macro_rules! impl_packing_compare {
 
                     $crate::seq_t!(W in $T {
                          match width {
-                             #(W => Self::unpack_cmp::<W, V, F>(
-                                 arrayref::array_ref![input, 0, 1024 * W / <$T>::T],
-                                 output,
-                                 comparison,
-                                 value
-                             ),)*
+                             #(W => {
+                                 const B: usize = 1024 * W / <$T>::T;
+                                 Self::unpack_cmp::<W, B, V, F>(
+                                     arrayref::array_ref![input, 0, 1024 * W / <$T>::T],
+                                     output,
+                                     comparison,
+                                     value
+                                )
+                             },)*
                              _ => unreachable!("Unsupported width: {}", width)
                          }
                      })
@@ -105,17 +109,18 @@ mod tests {
     fn test_unpack_eq() {
         type T = u32;
         const W: usize = 10;
+        const B: usize = 1024 * W / T::T;
 
         let values = array::from_fn(|i| i as T % (1 << W));
 
         let mut packed = [0; (128 * W) / size_of::<T>()];
-        T::pack::<W>(&values, &mut packed);
+        T::pack::<W, B>(&values, &mut packed);
 
         // Check equality against every value of the vector
         for v in 0..1024 {
             let cmp = {
                 let mut output = [false; 1024];
-                T::unpack_cmp::<W, _, _>(&packed, &mut output, |a, b| a == b, v);
+                T::unpack_cmp::<W, B, _, _>(&packed, &mut output, |a, b| a == b, v);
                 output
             };
 

--- a/src/bitpacking_cmp.rs
+++ b/src/bitpacking_cmp.rs
@@ -1,4 +1,4 @@
-use crate::{FastLanes, FastLanesComparable, supported_bit_width};
+use crate::{supported_bit_width, FastLanes, FastLanesComparable};
 
 pub trait BitPackingCompare: FastLanes {
     /// A fused unpack (see `BitPacking::unpack`) and compare and pack into bit bools.

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -1,19 +1,18 @@
 #![allow(unused_assignments)]
 
-use crate::{BitPackWidth, BitPacking, FastLanes, SupportedBitPackWidth, iterate, unpack};
+use crate::{iterate, unpack, BitPacking, FastLanes, supported_bit_width};
 use paste::paste;
 
 pub trait Delta: BitPacking {
-    fn delta(input: &[Self; 1024], base: &[Self; Self::LANES], output: &mut [Self; 1024]);
+    fn delta<const LANES: usize>(input: &[Self; 1024], base: &[Self; LANES], output: &mut [Self; 1024]);
 
-    fn undelta(input: &[Self; 1024], base: &[Self; Self::LANES], output: &mut [Self; 1024]);
+    fn undelta<const LANES: usize>(input: &[Self; 1024], base: &[Self; LANES], output: &mut [Self; 1024]);
 
-    fn undelta_pack<const W: usize>(
-        input: &[Self; 1024 * W / Self::T],
-        base: &[Self; Self::LANES],
+    fn undelta_pack<const LANES: usize, const W: usize, const B: usize>(
+        input: &[Self; B],
+        base: &[Self; LANES],
         output: &mut [Self; 1024],
-    ) where
-        BitPackWidth<W>: SupportedBitPackWidth<Self>;
+    );
 }
 
 macro_rules! impl_delta {
@@ -21,7 +20,11 @@ macro_rules! impl_delta {
         paste! {
             impl Delta for $T {
                 #[inline(never)]
-                fn delta(input: &[Self; 1024], base: &[Self; Self::LANES], output: &mut [Self; 1024]) {
+                fn delta<const LANES: usize>(input: &[Self; 1024], base: &[Self; LANES], output: &mut [Self; 1024]) {
+                    const {
+                        assert!(LANES == Self::LANES);
+                    }
+
                     for lane in 0..Self::LANES {
                         let mut prev = base[lane];
                         iterate!($T, lane, |$idx| {
@@ -33,8 +36,11 @@ macro_rules! impl_delta {
                 }
 
                 #[inline(never)]
-                fn undelta(input: &[Self; 1024], base: &[Self; Self::LANES], output: &mut [Self; 1024]) {
-                    for lane in 0..Self::LANES {
+                fn undelta<const LANES: usize>(input: &[Self; 1024], base: &[Self; LANES], output: &mut [Self; 1024]) {
+                    const {
+                        assert!(LANES == Self::LANES);
+                    }
+                    for lane in 0..LANES {
                         let mut prev = base[lane];
                         iterate!($T, lane, |$idx| {
                             let next = input[$idx].wrapping_add(prev);
@@ -45,13 +51,17 @@ macro_rules! impl_delta {
                 }
 
                 #[inline(never)]
-                fn undelta_pack<const W: usize>(
-                    input: &[Self; 1024 * W / Self::T],
-                    base: &[Self; Self::LANES],
+                fn undelta_pack<const LANES: usize, const W: usize, const B: usize>(
+                    input: &[Self; B],
+                    base: &[Self; LANES],
                     output: &mut [Self; 1024],
-                ) where
-                    BitPackWidth<W>: SupportedBitPackWidth<Self>,
-                {
+                ) {
+                    const {
+                        assert!(LANES == Self::LANES);
+                        assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
+                        assert!(B == 1024 * W / Self::T);
+                    }
+
                     for lane in 0..Self::LANES {
                         let mut prev = base[lane];
                         unpack!($T, W, input, lane, |$idx, $elem| {
@@ -79,7 +89,10 @@ mod test {
 
     #[test]
     fn test_delta() {
+        const LANES: usize = u16::LANES;
         const W: usize = 15;
+        const B: usize = 1024 * W / u16::T;
+
         let mut values: [u16; 1024] = [0; 1024];
         for i in 0..1024 {
             values[i] = (i / 8) as u16;
@@ -92,15 +105,15 @@ mod test {
         Delta::delta(&transposed, &[0; 64], &mut deltas);
 
         let mut packed = [0; 128 * W / size_of::<u16>()];
-        BitPacking::pack::<W>(&deltas, &mut packed);
+        BitPacking::pack::<W, B>(&deltas, &mut packed);
 
         // Fused kernel
         let mut unpacked = [0; 1024];
-        Delta::undelta_pack::<W>(&packed, &[0; 64], &mut unpacked);
+        Delta::undelta_pack::<LANES, W, B>(&packed, &[0; 64], &mut unpacked);
         assert_eq!(transposed, unpacked);
 
         // Unfused kernel
-        BitPacking::unpack::<W>(&packed, &mut unpacked);
+        BitPacking::unpack::<W, B>(&packed, &mut unpacked);
         let mut undelta = [0; 1024];
         Delta::undelta(&unpacked, &[0; 64], &mut undelta);
         assert_eq!(transposed, undelta);

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -1,12 +1,20 @@
 #![allow(unused_assignments)]
 
-use crate::{iterate, unpack, BitPacking, FastLanes, supported_bit_width};
+use crate::{iterate, supported_bit_width, unpack, BitPacking, FastLanes};
 use paste::paste;
 
 pub trait Delta: BitPacking {
-    fn delta<const LANES: usize>(input: &[Self; 1024], base: &[Self; LANES], output: &mut [Self; 1024]);
+    fn delta<const LANES: usize>(
+        input: &[Self; 1024],
+        base: &[Self; LANES],
+        output: &mut [Self; 1024],
+    );
 
-    fn undelta<const LANES: usize>(input: &[Self; 1024], base: &[Self; LANES], output: &mut [Self; 1024]);
+    fn undelta<const LANES: usize>(
+        input: &[Self; 1024],
+        base: &[Self; LANES],
+        output: &mut [Self; 1024],
+    );
 
     fn undelta_pack<const LANES: usize, const W: usize, const B: usize>(
         input: &[Self; B],

--- a/src/ffor.rs
+++ b/src/ffor.rs
@@ -1,4 +1,4 @@
-use crate::{pack, unpack, BitPacking, FastLanes, supported_bit_width};
+use crate::{pack, supported_bit_width, unpack, BitPacking, FastLanes};
 use paste::paste;
 
 pub trait FoR: BitPacking {

--- a/src/ffor.rs
+++ b/src/ffor.rs
@@ -1,33 +1,34 @@
-use crate::{BitPackWidth, BitPacking, FastLanes, SupportedBitPackWidth, pack, unpack};
+use crate::{pack, unpack, BitPacking, FastLanes, supported_bit_width};
 use paste::paste;
 
 pub trait FoR: BitPacking {
-    fn for_pack<const W: usize>(
+    fn for_pack<const W: usize, const B: usize>(
         input: &[Self; 1024],
         reference: Self,
-        output: &mut [Self; 1024 * W / Self::T],
-    ) where
-        BitPackWidth<W>: SupportedBitPackWidth<Self>;
+        output: &mut [Self; B],
+    );
 
-    fn unfor_pack<const W: usize>(
-        input: &[Self; 1024 * W / Self::T],
+    fn unfor_pack<const W: usize, const B: usize>(
+        input: &[Self; B],
         reference: Self,
         output: &mut [Self; 1024],
-    ) where
-        BitPackWidth<W>: SupportedBitPackWidth<Self>;
+    );
 }
 
 macro_rules! impl_for {
     ($T:ty) => {
         paste! {
             impl FoR for $T {
-                fn for_pack<const W: usize>(
+                fn for_pack<const W: usize, const B: usize>(
                     input: &[Self; 1024],
                     reference: Self,
-                    output: &mut [Self; 1024 * W / Self::T],
-                ) where
-                    BitPackWidth<W>: SupportedBitPackWidth<Self>,
-                {
+                    output: &mut [Self; B],
+                ) {
+                    const {
+                        assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
+                        assert!(B == 1024 * W / Self::T);
+                    }
+
                     for lane in 0..Self::LANES {
                         pack!($T, W, output, lane, |$idx| {
                             input[$idx].wrapping_sub(reference)
@@ -35,13 +36,16 @@ macro_rules! impl_for {
                     }
                 }
 
-                fn unfor_pack<const W: usize>(
-                    input: &[Self; 1024 * W / Self::T],
+                fn unfor_pack<const W: usize, const B: usize>(
+                    input: &[Self; B],
                     reference: Self,
                     output: &mut [Self; 1024],
-                ) where
-                    BitPackWidth<W>: SupportedBitPackWidth<Self>,
-                {
+                ) {
+                    const {
+                        assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
+                        assert!(B == 1024 * W / Self::T);
+                    }
+
                     for lane in 0..Self::LANES {
                         unpack!($T, W, input, lane, |$idx, $elem| {
                             output[$idx] = $elem.wrapping_add(reference)
@@ -66,16 +70,18 @@ mod test {
     #[test]
     fn test_ffor() {
         const W: usize = 15;
+        const B: usize = 1024 * W / u16::T;
+
         let mut values: [u16; 1024] = [0; 1024];
         for i in 0..1024 {
             values[i] = (i % (1 << W)) as u16;
         }
 
         let mut packed = [0; 128 * W / size_of::<u16>()];
-        FoR::for_pack::<W>(&values, 10, &mut packed);
+        FoR::for_pack::<W, B>(&values, 10, &mut packed);
 
         let mut unpacked = [0; 1024];
-        BitPacking::unpack::<W>(&packed, &mut unpacked);
+        BitPacking::unpack::<W, B>(&packed, &mut unpacked);
 
         for (i, (a, b)) in values.iter().zip(unpacked.iter()).enumerate() {
             assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![no_std]
 
 extern crate alloc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ macro_rules! impl_fastlanes_comparable {
             type Bitpacked = $bitpacked_type;
 
             #[inline]
-            #[allow(unnecessary_transmutes)]
+            #[allow(unnecessary_transmutes, clippy::useless_transmute)]
             fn as_unpacked(inner: Self::Bitpacked) -> Self {
                 unsafe { core::mem::transmute(inner) }
             }
@@ -103,6 +103,7 @@ mod tests {
     #[test]
     fn pack_u16_into_u3_no_unsafe() {
         const WIDTH: usize = 3;
+        const B: usize = 128 * WIDTH / size_of::<u16>();
 
         // Generate some values.
         let mut values: [u16; 1024] = [0; 1024];
@@ -111,7 +112,6 @@ mod tests {
         }
 
         // Pack the values.
-        const B: usize = 128 * WIDTH / size_of::<u16>();
         let mut packed = [0; B];
         BitPacking::pack::<WIDTH, B>(&values, &mut packed);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![allow(incomplete_features)]
-#![feature(generic_const_exprs)]
 #![no_std]
 
 extern crate alloc;
@@ -33,12 +32,6 @@ impl FastLanes for u16 {}
 impl FastLanes for u32 {}
 impl FastLanes for u64 {}
 
-pub struct Pred<const B: bool>;
-
-pub trait Satisfied {}
-
-impl Satisfied for Pred<true> {}
-
 // Macro for repeating a code block bit_size_of::<T> times.
 #[macro_export]
 macro_rules! seq_t {
@@ -46,6 +39,16 @@ macro_rules! seq_t {
     ($ident:ident in u16 $body:tt) => {seq_macro::seq!($ident in 0..16 $body)};
     ($ident:ident in u32 $body:tt) => {seq_macro::seq!($ident in 0..32 $body)};
     ($ident:ident in u64 $body:tt) => {seq_macro::seq!($ident in 0..64 $body)};
+}
+
+const fn supported_bit_width(width: usize, type_width: usize) -> bool {
+    match type_width {
+        8 => width <= 8,
+        16 => width <= 16,
+        32 => width <= 32,
+        64 => width <= 64,
+        _ => unreachable!(),
+    }
 }
 
 pub trait FastLanesComparable: Copy {
@@ -60,7 +63,7 @@ macro_rules! impl_fastlanes_comparable {
             type Bitpacked = $bitpacked_type;
 
             #[inline]
-            #[allow(clippy::useless_transmute)]
+            #[allow(unnecessary_transmutes)]
             fn as_unpacked(inner: Self::Bitpacked) -> Self {
                 unsafe { core::mem::transmute(inner) }
             }
@@ -108,19 +111,20 @@ mod tests {
         }
 
         // Pack the values.
-        let mut packed = [0; 128 * WIDTH / size_of::<u16>()];
-        BitPacking::pack::<WIDTH>(&values, &mut packed);
+        const B: usize = 128 * WIDTH / size_of::<u16>();
+        let mut packed = [0; B];
+        BitPacking::pack::<WIDTH, B>(&values, &mut packed);
 
         // Unpack the values.
         let mut unpacked = [0u16; 1024];
-        BitPacking::unpack::<WIDTH>(&packed, &mut unpacked);
+        BitPacking::unpack::<WIDTH, B>(&packed, &mut unpacked);
         assert_eq!(values, unpacked);
 
         // Unpack a single value at index 14.
         // Note that for more than ~10 values, it can be faster to unpack all values and then
         // access the desired one.
         for i in 0..1024 {
-            assert_eq!(BitPacking::unpack_single::<WIDTH>(&packed, i), values[i]);
+            assert_eq!(BitPacking::unpack_single::<WIDTH, B>(&packed, i), values[i]);
         }
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -193,7 +193,7 @@ mod test {
         }
 
         let mut packed_orig: [u16; 960] = [0; 960];
-        BitPacking::pack::<15>(&values, &mut packed_orig);
+        BitPacking::pack::<15, 960>(&values, &mut packed_orig);
 
         let mut unpacked: [u16; 1024] = [0; 1024];
         for lane in 0..u16::LANES {

--- a/src/transpose.rs
+++ b/src/transpose.rs
@@ -1,4 +1,4 @@
-use crate::{FL_ORDER, FastLanes};
+use crate::{FastLanes, FL_ORDER};
 use seq_macro::seq;
 
 pub trait Transpose: FastLanes {


### PR DESCRIPTION
This removes our use of the `generic_const_exprs` nightly feature. This makes the API a bit more annoying by requiring an additional `const B: usize` parameter that was previously computed as `1024 * W / <$T>::T` on most of the safe public API methods.

I've looked on crates.io and it appears the only published crates with depend on fastlanes-rs are Vortex and [LiquidCache](https://github.com/XiangpengHao/liquid-cache/blob/cdaf09fa87523d614c99d7f3e514dbe900d01ca3/src/liquid_parquet/src/liquid_array/raw/bit_pack_array.rs#L8). Both only use the `unchecked` APIs, so this should not break either of them.

All existing tests continue to pass.

I chose Rust Edition 2021 to be maximally compatible with downstream users, and we don't really make use for 2024 language features anyway.