### PR TITLE
feat: fastlanes rle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,7 @@ harness = false
 [[bench]]
 name = "transpose"
 harness = false
+
+[[bench]]
+name = "rle"
+harness = false

--- a/benches/rle.rs
+++ b/benches/rle.rs
@@ -1,0 +1,90 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use fastlanes::RLE;
+use std::mem::size_of;
+
+fn rle(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rle");
+
+    group.bench_function("encode u32", |b| {
+        let input: [u32; 1024] = std::array::from_fn(|i| (i / 100 + 1) as u32);
+        let mut rle_vals = [0u32; 1024];
+        let mut rle_idxs = [0u16; 1024];
+
+        b.iter(|| {
+            let unique_count = u32::encode(black_box(&input), &mut rle_vals, &mut rle_idxs);
+            black_box(unique_count);
+        });
+    });
+
+    group.bench_function("decode u32", |b| {
+        let input: [u32; 1024] = std::array::from_fn(|i| (i / 100 + 1) as u32);
+        let mut rle_vals = [0u32; 1024];
+        let mut rle_idxs = [0u16; 1024];
+        let unique_count = u32::encode(&input, &mut rle_vals, &mut rle_idxs);
+
+        let mut output = [0u32; 1024];
+
+        b.iter(|| {
+            u32::decode(
+                black_box(&rle_vals[..unique_count]),
+                black_box(&rle_idxs),
+                &mut output,
+            );
+            black_box(&output);
+        });
+    });
+}
+
+fn throughput(c: &mut Criterion) {
+    const NUM_BATCHES: usize = 1024;
+    const N: usize = 1024 * NUM_BATCHES;
+
+    let mut group = c.benchmark_group("rle_throughput");
+    group.throughput(Throughput::Bytes(N as u64 * size_of::<u32>() as u64));
+
+    let input_data: Vec<u32> = (0..N).map(|i| (i / 100) as u32).collect();
+
+    group.bench_function("compress", |b| {
+        b.iter(|| {
+            for batch in 0..NUM_BATCHES {
+                let batch_start = batch * 1024;
+                let input_batch: [u32; 1024] = std::array::from_fn(|i| input_data[batch_start + i]);
+
+                let mut rle_vals = [0u32; 1024];
+                let mut rle_idxs = [0u16; 1024];
+
+                let unique_count =
+                    u32::encode(black_box(&input_batch), &mut rle_vals, &mut rle_idxs);
+                black_box(unique_count);
+            }
+        });
+    });
+
+    let mut encoded_batches = Vec::new();
+    for batch in 0..NUM_BATCHES {
+        let batch_start = batch * 1024;
+        let input_batch: [u32; 1024] = std::array::from_fn(|i| input_data[batch_start + i]);
+
+        let mut rle_vals = [0u32; 1024];
+        let mut rle_idxs = [0u16; 1024];
+        let unique_count = u32::encode(&input_batch, &mut rle_vals, &mut rle_idxs);
+        encoded_batches.push((rle_vals, rle_idxs, unique_count));
+    }
+
+    group.bench_function("decompress", |b| {
+        b.iter(|| {
+            for (rle_vals, rle_idxs, unique_count) in &encoded_batches {
+                let mut output = [0u32; 1024];
+                u32::decode(
+                    black_box(&rle_vals[..*unique_count]),
+                    black_box(rle_idxs),
+                    &mut output,
+                );
+                black_box(&output);
+            }
+        });
+    });
+}
+
+criterion_group!(benches, rle, throughput);
+criterion_main!(benches);

--- a/benches/rle.rs
+++ b/benches/rle.rs
@@ -5,7 +5,7 @@ use std::mem::size_of;
 fn rle(c: &mut Criterion) {
     let mut group = c.benchmark_group("rle");
 
-    group.bench_function("encode u32", |b| {
+    group.bench_function("rle encode u32", |b| {
         let input: [u32; 1024] = std::array::from_fn(|i| (i / 100 + 1) as u32);
         let mut rle_vals = [0u32; 1024];
         let mut rle_idxs = [0u16; 1024];
@@ -16,7 +16,7 @@ fn rle(c: &mut Criterion) {
         });
     });
 
-    group.bench_function("decode u32", |b| {
+    group.bench_function("rle decode u32", |b| {
         let input: [u32; 1024] = std::array::from_fn(|i| (i / 100 + 1) as u32);
         let mut rle_vals = [0u32; 1024];
         let mut rle_idxs = [0u16; 1024];
@@ -44,7 +44,7 @@ fn throughput(c: &mut Criterion) {
 
     let input_data: Vec<u32> = (0..N).map(|i| (i / 100) as u32).collect();
 
-    group.bench_function("compress", |b| {
+    group.bench_function("rle encode 32", |b| {
         b.iter(|| {
             for batch in 0..NUM_BATCHES {
                 let batch_start = batch * 1024;
@@ -71,7 +71,7 @@ fn throughput(c: &mut Criterion) {
         encoded_batches.push((rle_vals, rle_idxs, unique_count));
     }
 
-    group.bench_function("decompress", |b| {
+    group.bench_function("rle decode 32", |b| {
         b.iter(|| {
             for (rle_vals, rle_idxs, unique_count) in &encoded_batches {
                 let mut output = [0u32; 1024];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,14 @@ mod bitpacking_cmp;
 mod delta;
 mod ffor;
 mod macros;
+mod rle;
 mod transpose;
 
 pub use bitpacking::*;
 pub use bitpacking_cmp::*;
 pub use delta::*;
 pub use ffor::*;
+pub use rle::*;
 pub use transpose::*;
 
 pub const FL_ORDER: [usize; 8] = [0, 4, 2, 6, 1, 5, 3, 7];

--- a/src/rle.rs
+++ b/src/rle.rs
@@ -5,9 +5,7 @@ pub trait RLE: FastLanes {
     /// Encode an array using Run-Length Encoding
     ///
     /// Creates a dictionary of unique values (`rle_vals`) and an index array
-    /// (`rle_idxs`) that maps each input position to a dictionary entry. The
-    /// index array can then be delta-encoded and bit-packed for efficient
-    /// storage.
+    /// (`rle_idxs`) that maps each input position to a dictionary entry. 
     ///
     /// # Returns
     /// The number of unique values in the dictionary

--- a/src/rle.rs
+++ b/src/rle.rs
@@ -5,7 +5,7 @@ pub trait RLE: FastLanes {
     /// Encode an array using Run-Length Encoding
     ///
     /// Creates a dictionary of unique values (`rle_vals`) and an index array
-    /// (`rle_idxs`) that maps each input position to a dictionary entry. 
+    /// (`rle_idxs`) that maps each input position to a dictionary entry.
     ///
     /// # Returns
     /// The number of unique values in the dictionary

--- a/src/rle.rs
+++ b/src/rle.rs
@@ -1,0 +1,171 @@
+use crate::FastLanes;
+use paste::paste;
+
+pub trait RLE: FastLanes {
+    /// Encode an array using Run-Length Encoding
+    ///
+    /// Creates a dictionary of unique values (`rle_vals`) and an index array
+    /// (`rle_idxs`) that maps each input position to a dictionary entry. The
+    /// index array can then be delta-encoded and bit-packed for efficient
+    /// storage.
+    ///
+    /// # Returns
+    /// The number of unique values in the dictionary
+    fn encode(
+        input: &[Self; 1024],
+        rle_vals: &mut [Self; 1024],
+        rle_idxs: &mut [u16; 1024],
+    ) -> usize;
+
+    /// Decode RLE-encoded data back to original values
+    ///
+    /// Takes the dictionary of unique values and indices, reconstructing the original array
+    fn decode(rle_vals: &[Self], rle_idxs: &[u16; 1024], output: &mut [Self; 1024]);
+}
+
+macro_rules! impl_rle {
+    ($T:ty) => {
+        paste! {
+            impl RLE for $T {
+                #[inline(never)]
+                fn encode(
+                    input: &[Self; 1024],
+                    rle_vals: &mut [Self; 1024],
+                    rle_idxs: &mut [u16; 1024],
+                ) -> usize {
+                    let mut pos_val = 0u16;
+                    let mut rle_val_idx = 0usize;
+
+                    let mut prev_val = input[0];
+                    rle_vals[rle_val_idx] = prev_val;
+                    rle_val_idx += 1;
+                    rle_idxs[0] = pos_val;
+
+                    for i in 1..1024 {
+                        let cur_val = input[i];
+                        if cur_val != prev_val {
+                            rle_vals[rle_val_idx] = cur_val;
+                            rle_val_idx += 1;
+                            pos_val += 1;
+                            prev_val = cur_val;
+                        }
+                        rle_idxs[i] = pos_val;
+                    }
+
+                    rle_val_idx
+                }
+
+                #[inline(never)]
+                fn decode(
+                    rle_vals: &[Self],
+                    rle_idxs: &[u16; 1024],
+                    output: &mut [Self; 1024],
+                ) {
+                    for i in 0..1024 {
+                        let idx = rle_idxs[i] as usize;
+                        output[i] = rle_vals[idx];
+                    }
+                }
+            }
+        }
+    };
+}
+
+impl_rle!(u8);
+impl_rle!(u16);
+impl_rle!(u32);
+impl_rle!(u64);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_rle_encode_unique_count() {
+        let input: [u32; 1024] = core::array::from_fn(|i| (i / 100 + 1) as u32);
+        let mut rle_vals = [0u32; 1024];
+        let mut rle_idxs = [0u16; 1024];
+
+        let unique_count = u32::encode(&input, &mut rle_vals, &mut rle_idxs);
+
+        assert_eq!(unique_count, 11);
+    }
+
+    #[test]
+    fn test_rle_encode_values() {
+        let input: [u32; 1024] = core::array::from_fn(|i| (i / 100 + 1) as u32);
+        let mut rle_vals = [0u32; 1024];
+        let mut rle_idxs = [0u16; 1024];
+
+        let unique_count = u32::encode(&input, &mut rle_vals, &mut rle_idxs);
+
+        // Check that RLE values are 1, 2, 3, ..., 11
+        for i in 0..unique_count {
+            assert_eq!(rle_vals[i], i as u32 + 1);
+        }
+    }
+
+    #[test]
+    fn test_rle_encode_index_groups() {
+        let input: [u32; 1024] = core::array::from_fn(|i| (i / 100 + 1) as u32);
+        let mut rle_vals = [0u32; 1024];
+        let mut rle_idxs = [0u16; 1024];
+
+        u32::encode(&input, &mut rle_vals, &mut rle_idxs);
+
+        for i in 0..100 {
+            assert_eq!(rle_idxs[i], 0);
+        }
+
+        for i in 100..200 {
+            assert_eq!(rle_idxs[i], 1);
+        }
+
+        for i in 1000..1024 {
+            assert_eq!(rle_idxs[i], 10);
+        }
+    }
+
+    #[test]
+    fn test_rle_encode_single_value() {
+        let input = [42u16; 1024];
+        let mut rle_vals = [0u16; 1024];
+        let mut rle_idxs = [0u16; 1024];
+
+        let unique_count = u16::encode(&input, &mut rle_vals, &mut rle_idxs);
+
+        assert_eq!(unique_count, 1);
+        assert_eq!(rle_vals[0], 42);
+
+        for &idx in &rle_idxs {
+            assert_eq!(idx, 0);
+        }
+    }
+
+    #[test]
+    fn test_rle_encode_all_different() {
+        let input: [u8; 1024] = core::array::from_fn(|i| (i % 256) as u8);
+
+        let mut rle_vals = [0u8; 1024];
+        let mut rle_idxs = [0u16; 1024];
+
+        let unique_count = u8::encode(&input, &mut rle_vals, &mut rle_idxs);
+
+        // RLE creates a new dictionary entry every time the value changes,
+        // not when we encounter a new unique value.
+        assert_eq!(unique_count, 1024);
+    }
+
+    #[test]
+    fn test_rle_round_trip() {
+        let input: [u8; 1024] = core::array::from_fn(|i| (i % 256) as u8);
+
+        let mut rle_vals = [0u8; 1024];
+        let mut rle_idxs = [0u16; 1024];
+        let unique_count = u8::encode(&input, &mut rle_vals, &mut rle_idxs);
+
+        let mut decoded = [0u8; 1024];
+        u8::decode(&rle_vals[..unique_count], &rle_idxs, &mut decoded);
+        assert_eq!(input, decoded);
+    }
+}


### PR DESCRIPTION
Implementation of: https://github.com/cwida/FastLanes/blob/dev/src/primitive/rle/rle.cpp

Fastlanes run-length:
```
cargo bench rle

rle_throughput/rle encode 32
                        time:   [486.61 µs 487.76 µs 489.06 µs]
                        thrpt:  [7.9872 GiB/s 8.0085 GiB/s 8.0275 GiB/s]

rle_throughput/rle decode 32
                        time:   [312.19 µs 312.56 µs 312.94 µs]
                        thrpt:  [12.482 GiB/s 12.498 GiB/s 12.512 GiB/s]
```

non-Fastlanes run-end:
```
cargo bench -p vortex runend

single_encoding_throughput  fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ runend_compress_u32      2.359 ms      │ 3.532 ms      │ 2.529 ms      │ 2.765 ms      │ 100     │ 100
│                           1.695 GB/s    │ 1.132 GB/s    │ 1.581 GB/s    │ 1.446 GB/s    │         │
╰─ runend_decompress_u32    844.7 µs      │ 938.3 µs      │ 919.6 µs      │ 915.6 µs      │ 100     │ 100
                            4.735 GB/s    │ 4.262 GB/s    │ 4.349 GB/s    │ 4.368 GB/s    │         │
```
