### PR TITLE
Narrow down the scope of paste macro

### DIFF
--- a/src/bitpacking.rs
+++ b/src/bitpacking.rs
@@ -47,179 +47,177 @@ pub trait BitPacking: FastLanes {
 
 macro_rules! impl_packing {
     ($T:ty) => {
-        paste! {
-            impl BitPacking for $T {
-                #[inline(never)]
-                fn pack<const W: usize, const B: usize>(
-                    input: &[Self; 1024],
-                    output: &mut [Self; B],
-                ) {
-                    const {
-                        assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
-                        assert!(B == 1024 * W / Self::T);
-                    }
-
-
-                    for lane in 0..Self::LANES {
-                        pack!($T, W, output, lane, |$idx| {
-                            input[$idx]
-                        });
-                    }
+        impl BitPacking for $T {
+            #[inline(never)]
+            fn pack<const W: usize, const B: usize>(
+                input: &[Self; 1024],
+                output: &mut [Self; B],
+            ) {
+                const {
+                    assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
+                    assert!(B == 1024 * W / Self::T);
                 }
 
-                unsafe fn unchecked_pack(width: usize, input: &[Self], output: &mut [Self]) {
-                    let packed_len = 128 * width / size_of::<Self>();
-                    debug_assert_eq!(output.len(), packed_len, "Output buffer must be of size 1024 * W / T");
-                    debug_assert_eq!(input.len(), 1024, "Input buffer must be of size 1024");
-                    debug_assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
 
-                    seq_t!(W in $T {
-                        match width {
-                            #(W => {
-                                const B: usize = 1024 * W / <$T>::T;
-                                Self::pack::<W, B>(
-                                    array_ref![input, 0, 1024],
-                                    array_mut_ref![output, 0, B],
-                                )
-                            },)*
-                            // seq_t has exclusive upper bound
-                            Self::T => {
-                                // How large is the target buffer size?
-                                const W: usize = <$T>::T;
-                                const B: usize = 1024;
-                                Self::pack::<W, B>(
-                                    array_ref![input, 0, 1024],
-                                    array_mut_ref![output, 0, 1024],
-                                )
-                            },
-                            _ => unreachable!("Unsupported width: {}", width)
-                        }
-                    })
+                for lane in 0..Self::LANES {
+                    pack!($T, W, output, lane, |$idx| {
+                        input[$idx]
+                    });
+                }
+            }
+
+            unsafe fn unchecked_pack(width: usize, input: &[Self], output: &mut [Self]) {
+                let packed_len = 128 * width / size_of::<Self>();
+                debug_assert_eq!(output.len(), packed_len, "Output buffer must be of size 1024 * W / T");
+                debug_assert_eq!(input.len(), 1024, "Input buffer must be of size 1024");
+                debug_assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
+
+                paste!(seq_t!(W in $T {
+                    match width {
+                        #(W => {
+                            const B: usize = 1024 * W / <$T>::T;
+                            Self::pack::<W, B>(
+                                array_ref![input, 0, 1024],
+                                array_mut_ref![output, 0, B],
+                            )
+                        },)*
+                        // seq_t has exclusive upper bound
+                        Self::T => {
+                            // How large is the target buffer size?
+                            const W: usize = <$T>::T;
+                            const B: usize = 1024;
+                            Self::pack::<W, B>(
+                                array_ref![input, 0, 1024],
+                                array_mut_ref![output, 0, 1024],
+                            )
+                        },
+                        _ => unreachable!("Unsupported width: {}", width)
+                    }
+                }))
+            }
+
+            #[inline(never)]
+            fn unpack<const W: usize, const B: usize>(
+                input: &[Self; B],
+                output: &mut [Self; 1024],
+            ) {
+                const {
+                    assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
+                    assert!(B == 1024 * W / Self::T);
                 }
 
-                #[inline(never)]
-                fn unpack<const W: usize, const B: usize>(
-                    input: &[Self; B],
-                    output: &mut [Self; 1024],
-                ) {
-                    const {
-                        assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
-                        assert!(B == 1024 * W / Self::T);
-                    }
 
+                for lane in 0..Self::LANES {
+                    unpack!($T, W, input, lane, |$idx, $elem| {
+                        output[$idx] = $elem
+                    });
+                }
+            }
 
-                    for lane in 0..Self::LANES {
-                        unpack!($T, W, input, lane, |$idx, $elem| {
-                            output[$idx] = $elem
-                        });
+            unsafe fn unchecked_unpack(width: usize, input: &[Self], output: &mut [Self]) {
+                let packed_len = 128 * width / size_of::<Self>();
+                debug_assert_eq!(input.len(), packed_len, "Input buffer must be of size 1024 * W / T");
+                debug_assert_eq!(output.len(), 1024, "Output buffer must be of size 1024");
+                debug_assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
+
+                paste!(seq_t!(W in $T {
+                    match width {
+                        #(W => {
+                            const B: usize = 1024 * W / <$T>::T;
+                            Self::unpack::<W, B>(
+                                array_ref![input, 0, B],
+                                array_mut_ref![output, 0, 1024],
+                            )
+                        },)*
+                        // seq_t has exclusive upper bound
+                        Self::T => {
+                            const W: usize = <$T>::T;
+                            const B: usize = 1024;
+                            Self::unpack::<W, B>(
+                                array_ref![input, 0, 1024],
+                                array_mut_ref![output, 0, 1024],
+                            )
+                        },
+                        _ => unreachable!("Unsupported width: {}", width)
                     }
+                }))
+            }
+
+            /// Unpacks a single element at the provided index from a packed array of 1024 `W` bit elements.
+            fn unpack_single<const W: usize, const B: usize>(packed: &[Self; B], index: usize) -> Self
+            {
+                const {
+                    assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
+                    assert!(B == 1024 * W / Self::T);
                 }
 
-                unsafe fn unchecked_unpack(width: usize, input: &[Self], output: &mut [Self]) {
-                    let packed_len = 128 * width / size_of::<Self>();
-                    debug_assert_eq!(input.len(), packed_len, "Input buffer must be of size 1024 * W / T");
-                    debug_assert_eq!(output.len(), 1024, "Output buffer must be of size 1024");
-                    debug_assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
-
-                    seq_t!(W in $T {
-                        match width {
-                            #(W => {
-                                const B: usize = 1024 * W / <$T>::T;
-                                Self::unpack::<W, B>(
-                                    array_ref![input, 0, B],
-                                    array_mut_ref![output, 0, 1024],
-                                )
-                            },)*
-                            // seq_t has exclusive upper bound
-                            Self::T => {
-                                const W: usize = <$T>::T;
-                                const B: usize = 1024;
-                                Self::unpack::<W, B>(
-                                    array_ref![input, 0, 1024],
-                                    array_mut_ref![output, 0, 1024],
-                                )
-                            },
-                            _ => unreachable!("Unsupported width: {}", width)
-                        }
-                    })
+                if W == 0 {
+                    // Special case for W=0, we just need to zero the output.
+                    return 0 as $T;
                 }
 
-                /// Unpacks a single element at the provided index from a packed array of 1024 `W` bit elements.
-                fn unpack_single<const W: usize, const B: usize>(packed: &[Self; B], index: usize) -> Self
-                {
-                    const {
-                        assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
-                        assert!(B == 1024 * W / Self::T);
-                    }
+                // We can think of the input array as effectively a row-major, left-to-right
+                // 2-D array of with `Self::LANES` columns and `Self::T` rows.
+                //
+                // Meanwhile, we can think of the packed array as either:
+                //      1. `Self::T` rows of W-bit elements, with `Self::LANES` columns
+                //      2. `W` rows of `Self::T`-bit words, with `Self::LANES` columns
+                //
+                // Bitpacking involves a transposition of the input array ordering, such that
+                // decompression can be fused efficiently with encodings like delta and RLE.
+                //
+                // First step, we need to get the lane and row for interpretation #1 above.
+                assert!(index < 1024, "Index must be less than 1024, got {}", index);
+                let (lane, row): (usize, usize) = {
+                    const LANES: [u8; 1024] = lanes_by_index::<$T>();
+                    const ROWS: [u8; 1024] = rows_by_index::<$T>();
+                    (LANES[index] as usize, ROWS[index] as usize)
+                };
 
-                    if W == 0 {
-                        // Special case for W=0, we just need to zero the output.
-                        return 0 as $T;
-                    }
-
-                    // We can think of the input array as effectively a row-major, left-to-right
-                    // 2-D array of with `Self::LANES` columns and `Self::T` rows.
-                    //
-                    // Meanwhile, we can think of the packed array as either:
-                    //      1. `Self::T` rows of W-bit elements, with `Self::LANES` columns
-                    //      2. `W` rows of `Self::T`-bit words, with `Self::LANES` columns
-                    //
-                    // Bitpacking involves a transposition of the input array ordering, such that
-                    // decompression can be fused efficiently with encodings like delta and RLE.
-                    //
-                    // First step, we need to get the lane and row for interpretation #1 above.
-                    assert!(index < 1024, "Index must be less than 1024, got {}", index);
-                    let (lane, row): (usize, usize) = {
-                        const LANES: [u8; 1024] = lanes_by_index::<$T>();
-                        const ROWS: [u8; 1024] = rows_by_index::<$T>();
-                        (LANES[index] as usize, ROWS[index] as usize)
-                    };
-
-                    if W == <$T>::T {
-                        // Special case for W==T, we can just read the value directly
-                        return packed[<$T>::LANES * row + lane];
-                    }
-
-                    let mask: $T = (1 << (W % <$T>::T)) - 1;
-                    let start_bit = row * W;
-                    let start_word = start_bit / <$T>::T;
-                    let lo_shift = start_bit % <$T>::T;
-                    let remaining_bits = <$T>::T - lo_shift;
-
-                    let lo = packed[<$T>::LANES * start_word + lane] >> lo_shift;
-                    return if remaining_bits >= W {
-                        // in this case we will mask out all bits of hi word
-                        lo & mask
-                    } else {
-                        // guaranteed that lo_shift > 0 and thus remaining_bits < T
-                        let hi = packed[<$T>::LANES * (start_word + 1) + lane] << remaining_bits;
-                        (lo | hi) & mask
-                    };
+                if W == <$T>::T {
+                    // Special case for W==T, we can just read the value directly
+                    return packed[<$T>::LANES * row + lane];
                 }
 
-                unsafe fn unchecked_unpack_single(width: usize, packed: &[Self], index: usize) -> Self {
-                    const T: usize = <$T>::T;
+                let mask: $T = (1 << (W % <$T>::T)) - 1;
+                let start_bit = row * W;
+                let start_word = start_bit / <$T>::T;
+                let lo_shift = start_bit % <$T>::T;
+                let remaining_bits = <$T>::T - lo_shift;
 
-                    let packed_len = 128 * width / size_of::<Self>();
-                    debug_assert_eq!(packed.len(), packed_len, "Input buffer must be of size {}", packed_len);
-                    debug_assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
+                let lo = packed[<$T>::LANES * start_word + lane] >> lo_shift;
+                return if remaining_bits >= W {
+                    // in this case we will mask out all bits of hi word
+                    lo & mask
+                } else {
+                    // guaranteed that lo_shift > 0 and thus remaining_bits < T
+                    let hi = packed[<$T>::LANES * (start_word + 1) + lane] << remaining_bits;
+                    (lo | hi) & mask
+                };
+            }
 
-                    seq_t!(W in $T {
-                        match width {
-                            #(W => {
-                                const B: usize = 1024 * W / T;
-                                return <$T>::unpack_single::<W, B>(array_ref![packed, 0, B], index);
-                            },)*
-                            // seq_t has exclusive upper bound
-                            T => {
-                                const W: usize = T;
-                                const B: usize = 1024;
-                                return <$T>::unpack_single::<W, B>(array_ref![packed, 0, 1024], index);
-                            },
-                            _ => unreachable!("Unsupported width: {}", width)
-                        }
-                    })
-                }
+            unsafe fn unchecked_unpack_single(width: usize, packed: &[Self], index: usize) -> Self {
+                const T: usize = <$T>::T;
+
+                let packed_len = 128 * width / size_of::<Self>();
+                debug_assert_eq!(packed.len(), packed_len, "Input buffer must be of size {}", packed_len);
+                debug_assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
+
+                paste!(seq_t!(W in $T {
+                    match width {
+                        #(W => {
+                            const B: usize = 1024 * W / T;
+                            return <$T>::unpack_single::<W, B>(array_ref![packed, 0, B], index);
+                        },)*
+                        // seq_t has exclusive upper bound
+                        T => {
+                            const W: usize = T;
+                            const B: usize = 1024;
+                            return <$T>::unpack_single::<W, B>(array_ref![packed, 0, 1024], index);
+                        },
+                        _ => unreachable!("Unsupported width: {}", width)
+                    }
+                }))
             }
         }
     };

--- a/src/bitpacking_cmp.rs
+++ b/src/bitpacking_cmp.rs
@@ -1,4 +1,7 @@
+use crate::seq_t;
+use crate::unpack;
 use crate::{supported_bit_width, FastLanes, FastLanesComparable};
+use paste::paste;
 
 pub trait BitPackingCompare: FastLanes {
     /// A fused unpack (see `BitPacking::unpack`) and compare and pack into bit bools.
@@ -33,61 +36,59 @@ pub trait BitPackingCompare: FastLanes {
 
 macro_rules! impl_packing_compare {
     ($T:ty) => {
-        paste::paste! {
-            impl BitPackingCompare for $T {
-                #[inline(never)]
-                fn unpack_cmp<const W: usize, const B: usize, V, F>(
-                    input: &[Self; B],
-                    output: &mut [bool; 1024],
-                    f: F,
-                    other: V,
-                )
-                where
-                    V: FastLanesComparable<Bitpacked = Self>,
-                    F: Fn(V, V) -> bool
-                {
-                    const {
-                        assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
-                        assert!(B == 1024 * W / Self::T);
-                    }
-
-                    for lane in (0..Self::LANES) {
-                        $crate::unpack!($T, W, input, lane, |$idx, $elem| {
-                            output[$idx] = f(V::as_unpacked($elem), other);
-                        });
-                    }
+        impl BitPackingCompare for $T {
+            #[inline(never)]
+            fn unpack_cmp<const W: usize, const B: usize, V, F>(
+                input: &[Self; B],
+                output: &mut [bool; 1024],
+                f: F,
+                other: V,
+            )
+            where
+                V: FastLanesComparable<Bitpacked = Self>,
+                F: Fn(V, V) -> bool
+            {
+                const {
+                    assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
+                    assert!(B == 1024 * W / Self::T);
                 }
 
-                unsafe fn unchecked_unpack_cmp<V, F>(
-                     width: usize,
-                     input: &[Self],
-                     output: &mut [bool; 1024],
-                     comparison: F,
-                     value: V,
-                )
-                where
-                    V: FastLanesComparable<Bitpacked = Self>,
-                    F: Fn(V, V) -> bool
-                {
-                    let packed_len = 128 * width / size_of::<Self>();
-                    debug_assert_eq!(input.len(), packed_len, "Input buffer must be of size 1024 * W / T");
-                    debug_assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
-
-                    $crate::seq_t!(W in $T {
-                         match width {
-                             #(W => {
-                                 const B: usize = 1024 * W / <$T>::T;
-                                 Self::unpack_cmp::<W, B, V, F>(
-                                     arrayref::array_ref![input, 0, 1024 * W / <$T>::T],
-                                     output,
-                                     comparison,
-                                     value
-                                )
-                             },)*
-                             _ => unreachable!("Unsupported width: {}", width)
-                         }
-                     })
+                for lane in (0..Self::LANES) {
+                    unpack!($T, W, input, lane, |$idx, $elem| {
+                        output[$idx] = f(V::as_unpacked($elem), other);
+                    });
                 }
+            }
+
+            unsafe fn unchecked_unpack_cmp<V, F>(
+                 width: usize,
+                 input: &[Self],
+                 output: &mut [bool; 1024],
+                 comparison: F,
+                 value: V,
+            )
+            where
+                V: FastLanesComparable<Bitpacked = Self>,
+                F: Fn(V, V) -> bool
+            {
+                let packed_len = 128 * width / size_of::<Self>();
+                debug_assert_eq!(input.len(), packed_len, "Input buffer must be of size 1024 * W / T");
+                debug_assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
+
+                paste!(seq_t!(W in $T {
+                    match width {
+                        #(W => {
+                            const B: usize = 1024 * W / <$T>::T;
+                            Self::unpack_cmp::<W, B, V, F>(
+                                arrayref::array_ref![input, 0, 1024 * W / <$T>::T],
+                                output,
+                                comparison,
+                                value
+                            )
+                        },)*
+                        _ => unreachable!("Unsupported width: {}", width)
+                    }
+                }))
             }
         }
     };

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -27,7 +27,11 @@ macro_rules! impl_delta {
     ($T:ty) => {
         impl Delta for $T {
             #[inline(never)]
-            fn delta<const LANES: usize>(input: &[Self; 1024], base: &[Self; LANES], output: &mut [Self; 1024]) {
+            fn delta<const LANES: usize>(
+                input: &[Self; 1024],
+                base: &[Self; LANES],
+                output: &mut [Self; 1024],
+            ) {
                 const {
                     assert!(LANES == Self::LANES);
                 }
@@ -43,7 +47,11 @@ macro_rules! impl_delta {
             }
 
             #[inline(never)]
-            fn undelta<const LANES: usize>(input: &[Self; 1024], base: &[Self; LANES], output: &mut [Self; 1024]) {
+            fn undelta<const LANES: usize>(
+                input: &[Self; 1024],
+                base: &[Self; LANES],
+                output: &mut [Self; 1024],
+            ) {
                 const {
                     assert!(LANES == Self::LANES);
                 }

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -25,59 +25,57 @@ pub trait Delta: BitPacking {
 
 macro_rules! impl_delta {
     ($T:ty) => {
-        paste! {
-            impl Delta for $T {
-                #[inline(never)]
-                fn delta<const LANES: usize>(input: &[Self; 1024], base: &[Self; LANES], output: &mut [Self; 1024]) {
-                    const {
-                        assert!(LANES == Self::LANES);
-                    }
-
-                    for lane in 0..Self::LANES {
-                        let mut prev = base[lane];
-                        iterate!($T, lane, |$idx| {
-                            let next = input[$idx];
-                            output[$idx] = next.wrapping_sub(prev);
-                            prev = next;
-                        });
-                    }
+        impl Delta for $T {
+            #[inline(never)]
+            fn delta<const LANES: usize>(input: &[Self; 1024], base: &[Self; LANES], output: &mut [Self; 1024]) {
+                const {
+                    assert!(LANES == Self::LANES);
                 }
 
-                #[inline(never)]
-                fn undelta<const LANES: usize>(input: &[Self; 1024], base: &[Self; LANES], output: &mut [Self; 1024]) {
-                    const {
-                        assert!(LANES == Self::LANES);
-                    }
-                    for lane in 0..LANES {
-                        let mut prev = base[lane];
-                        iterate!($T, lane, |$idx| {
-                            let next = input[$idx].wrapping_add(prev);
-                            output[$idx] = next;
-                            prev = next;
-                        });
-                    }
+                for lane in 0..Self::LANES {
+                    let mut prev = base[lane];
+                    iterate!($T, lane, |$idx| {
+                        let next = input[$idx];
+                        output[$idx] = next.wrapping_sub(prev);
+                        prev = next;
+                    });
+                }
+            }
+
+            #[inline(never)]
+            fn undelta<const LANES: usize>(input: &[Self; 1024], base: &[Self; LANES], output: &mut [Self; 1024]) {
+                const {
+                    assert!(LANES == Self::LANES);
+                }
+                for lane in 0..LANES {
+                    let mut prev = base[lane];
+                    iterate!($T, lane, |$idx| {
+                        let next = input[$idx].wrapping_add(prev);
+                        output[$idx] = next;
+                        prev = next;
+                    });
+                }
+            }
+
+            #[inline(never)]
+            fn undelta_pack<const LANES: usize, const W: usize, const B: usize>(
+                input: &[Self; B],
+                base: &[Self; LANES],
+                output: &mut [Self; 1024],
+            ) {
+                const {
+                    assert!(LANES == Self::LANES);
+                    assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
+                    assert!(B == 1024 * W / Self::T);
                 }
 
-                #[inline(never)]
-                fn undelta_pack<const LANES: usize, const W: usize, const B: usize>(
-                    input: &[Self; B],
-                    base: &[Self; LANES],
-                    output: &mut [Self; 1024],
-                ) {
-                    const {
-                        assert!(LANES == Self::LANES);
-                        assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
-                        assert!(B == 1024 * W / Self::T);
-                    }
-
-                    for lane in 0..Self::LANES {
-                        let mut prev = base[lane];
-                        unpack!($T, W, input, lane, |$idx, $elem| {
-                            let next = $elem.wrapping_add(prev);
-                            output[$idx] = next;
-                            prev = next;
-                        });
-                    }
+                for lane in 0..Self::LANES {
+                    let mut prev = base[lane];
+                    unpack!($T, W, input, lane, |$idx, $elem| {
+                        let next = $elem.wrapping_add(prev);
+                        output[$idx] = next;
+                        prev = next;
+                    });
                 }
             }
         }

--- a/src/ffor.rs
+++ b/src/ffor.rs
@@ -17,40 +17,38 @@ pub trait FoR: BitPacking {
 
 macro_rules! impl_for {
     ($T:ty) => {
-        paste! {
-            impl FoR for $T {
-                fn for_pack<const W: usize, const B: usize>(
-                    input: &[Self; 1024],
-                    reference: Self,
-                    output: &mut [Self; B],
-                ) {
-                    const {
-                        assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
-                        assert!(B == 1024 * W / Self::T);
-                    }
-
-                    for lane in 0..Self::LANES {
-                        pack!($T, W, output, lane, |$idx| {
-                            input[$idx].wrapping_sub(reference)
-                        });
-                    }
+        impl FoR for $T {
+            fn for_pack<const W: usize, const B: usize>(
+                input: &[Self; 1024],
+                reference: Self,
+                output: &mut [Self; B],
+            ) {
+                const {
+                    assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
+                    assert!(B == 1024 * W / Self::T);
                 }
 
-                fn unfor_pack<const W: usize, const B: usize>(
-                    input: &[Self; B],
-                    reference: Self,
-                    output: &mut [Self; 1024],
-                ) {
-                    const {
-                        assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
-                        assert!(B == 1024 * W / Self::T);
-                    }
+                for lane in 0..Self::LANES {
+                    pack!($T, W, output, lane, |$idx| {
+                        input[$idx].wrapping_sub(reference)
+                    });
+                }
+            }
 
-                    for lane in 0..Self::LANES {
-                        unpack!($T, W, input, lane, |$idx, $elem| {
-                            output[$idx] = $elem.wrapping_add(reference)
-                        });
-                    }
+            fn unfor_pack<const W: usize, const B: usize>(
+                input: &[Self; B],
+                reference: Self,
+                output: &mut [Self; 1024],
+            ) {
+                const {
+                    assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
+                    assert!(B == 1024 * W / Self::T);
+                }
+
+                for lane in 0..Self::LANES {
+                    unpack!($T, W, input, lane, |$idx, $elem| {
+                        output[$idx] = $elem.wrapping_add(reference)
+                    });
                 }
             }
         }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -118,9 +118,9 @@ macro_rules! unpack {
             if $W == 0 {
                 // Special case for W=0, we just need to zero the output.
                 // We'll still respect the iteration order in case the kernel has side effects.
+                let zero: $T = 0;
                 paste!(seq_t!(row in $T {
                     let idx = index(row, $lane);
-                    let zero: $T = 0;
                     __kernel__!(idx, zero);
                 }));
             } else if $W == T {

--- a/src/rle.rs
+++ b/src/rle.rs
@@ -1,5 +1,4 @@
 use crate::FastLanes;
-use paste::paste;
 
 pub trait RLE: FastLanes {
     /// Encode an array using Run-Length Encoding
@@ -21,58 +20,43 @@ pub trait RLE: FastLanes {
     fn decode(rle_vals: &[Self], rle_idxs: &[u16; 1024], output: &mut [Self; 1024]);
 }
 
-macro_rules! impl_rle {
-    ($T:ty) => {
-        paste! {
-            impl RLE for $T {
-                #[inline(never)]
-                fn encode(
-                    input: &[Self; 1024],
-                    rle_vals: &mut [Self; 1024],
-                    rle_idxs: &mut [u16; 1024],
-                ) -> usize {
-                    let mut pos_val = 0u16;
-                    let mut rle_val_idx = 0usize;
+impl<T: FastLanes> RLE for T {
+    #[inline(never)]
+    fn encode(
+        input: &[Self; 1024],
+        rle_vals: &mut [Self; 1024],
+        rle_idxs: &mut [u16; 1024],
+    ) -> usize {
+        let mut pos_val = 0u16;
+        let mut rle_val_idx = 0usize;
 
-                    let mut prev_val = unsafe { *input.get_unchecked(0) };
-                    unsafe { *rle_vals.get_unchecked_mut(rle_val_idx) = prev_val };
-                    rle_val_idx += 1;
-                    unsafe { *rle_idxs.get_unchecked_mut(0) = pos_val };
+        let mut prev_val = unsafe { *input.get_unchecked(0) };
+        unsafe { *rle_vals.get_unchecked_mut(rle_val_idx) = prev_val };
+        rle_val_idx += 1;
+        unsafe { *rle_idxs.get_unchecked_mut(0) = pos_val };
 
-                    for i in 1..1024 {
-                        let cur_val = unsafe { *input.get_unchecked(i) };
-                        if cur_val != prev_val {
-                            unsafe { *rle_vals.get_unchecked_mut(rle_val_idx) = cur_val };
-                            rle_val_idx += 1;
-                            pos_val += 1;
-                            prev_val = cur_val;
-                        }
-                        unsafe { *rle_idxs.get_unchecked_mut(i) = pos_val };
-                    }
-
-                    rle_val_idx
-                }
-
-                #[inline(never)]
-                fn decode(
-                    rle_vals: &[Self],
-                    rle_idxs: &[u16; 1024],
-                    output: &mut [Self; 1024],
-                ) {
-                    for i in 0..1024 {
-                        let idx = unsafe { *rle_idxs.get_unchecked(i) } as usize;
-                        unsafe { *output.get_unchecked_mut(i) = *rle_vals.get_unchecked(idx) };
-                    }
-                }
+        for i in 1..1024 {
+            let cur_val = unsafe { *input.get_unchecked(i) };
+            if cur_val != prev_val {
+                unsafe { *rle_vals.get_unchecked_mut(rle_val_idx) = cur_val };
+                rle_val_idx += 1;
+                pos_val += 1;
+                prev_val = cur_val;
             }
+            unsafe { *rle_idxs.get_unchecked_mut(i) = pos_val };
         }
-    };
-}
 
-impl_rle!(u8);
-impl_rle!(u16);
-impl_rle!(u32);
-impl_rle!(u64);
+        rle_val_idx
+    }
+
+    #[inline(never)]
+    fn decode(rle_vals: &[Self], rle_idxs: &[u16; 1024], output: &mut [Self; 1024]) {
+        for i in 0..1024 {
+            let idx = unsafe { *rle_idxs.get_unchecked(i) } as usize;
+            unsafe { *output.get_unchecked_mut(i) = *rle_vals.get_unchecked(idx) };
+        }
+    }
+}
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
This shifts the code around but gets us better ide support for the macro code. We only need paste to convert $ty token to $tt for seq macro