### PR TITLE
fix: black box input and output parameters

### DIFF
--- a/benches/bitpacking.rs
+++ b/benches/bitpacking.rs
@@ -18,6 +18,7 @@ fn pack(c: &mut Criterion) {
                     black_box(array_ref![values, 0, 1024]),
                     array_mut_ref![packed, 0, 192],
                 );
+                black_box(&packed);
             });
         });
 
@@ -26,7 +27,10 @@ fn pack(c: &mut Criterion) {
             const B: usize = 1024 * WIDTH / u16::T;
             let values = [3u16; 1024];
             let mut packed = [0; 128 * WIDTH / size_of::<u16>()];
-            b.iter(|| BitPacking::pack::<WIDTH, B>(black_box(&values), &mut packed));
+            b.iter(|| {
+                BitPacking::pack::<WIDTH, B>(black_box(&values), &mut packed);
+                black_box(packed);
+            });
         });
     }
 
@@ -42,7 +46,7 @@ fn pack(c: &mut Criterion) {
             let mut unpacked = [0u16; 1024];
             b.iter(|| {
                 BitPacking::unpack::<WIDTH, B>(&black_box(packed), &mut unpacked);
-                let _ = black_box(unpacked);
+                black_box(unpacked);
             });
         });
     }
@@ -59,7 +63,7 @@ fn pack(c: &mut Criterion) {
             let mut unpacked = [0u16; 1024];
             b.iter(|| {
                 unsafe { BitPacking::unchecked_unpack(WIDTH, &black_box(packed), &mut unpacked) };
-                let _ = black_box(unpacked);
+                black_box(unpacked);
             });
         });
     }
@@ -80,7 +84,7 @@ fn pack(c: &mut Criterion) {
                 for i in 0..1024 {
                     black_box::<u16>(BitPacking::unpack_single::<WIDTH, B>(
                         black_box(array_ref![packed, 0, 192]),
-                        i,
+                        black_box(i),
                     ));
                 }
             });
@@ -108,6 +112,7 @@ fn throughput(c: &mut Criterion) {
                     array_mut_ref![packed, i * OUTPUT_BATCH_SIZE, OUTPUT_BATCH_SIZE],
                 );
             }
+            black_box(&packed);
         });
     });
 
@@ -119,6 +124,7 @@ fn throughput(c: &mut Criterion) {
                     array_mut_ref![values, i * 1024, 1024],
                 );
             }
+            black_box(&values);
         });
     });
 }

--- a/benches/bitpacking.rs
+++ b/benches/bitpacking.rs
@@ -1,8 +1,9 @@
 use std::mem::size_of;
 
 use arrayref::{array_mut_ref, array_ref};
-use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use fastlanes::{BitPacking, FastLanes};
+use std::hint::black_box;
 
 fn pack(c: &mut Criterion) {
     {

--- a/benches/bitpacking_cmp.rs
+++ b/benches/bitpacking_cmp.rs
@@ -30,8 +30,8 @@ mod bench {
         bencher.bench_local(|| {
             unsafe {
                 BitPackingCompare::unchecked_unpack_cmp(
-                    W,
-                    &packed,
+                    black_box(W),
+                    black_box(&packed),
                     &mut unpacked,
                     |a, b| a == b,
                     black_box(value),
@@ -56,7 +56,7 @@ mod bench {
         let mut bools = [0u64; 16];
 
         bencher.bench_local(|| {
-            unsafe { T::unchecked_unpack(W, &packed, &mut unpacked) };
+            unsafe { T::unchecked_unpack(black_box(W), black_box(&packed), &mut unpacked) };
             collect_bool_cmp(&unpacked, &black_box(value), black_box(&mut bools));
             black_box(bools)
         });
@@ -75,7 +75,8 @@ mod bench {
         let mut unpacked = [T::zero(); 1024];
 
         bencher.bench_local(|| {
-            unsafe { T::unchecked_unpack(W, &packed, &mut unpacked) };
+            unsafe { T::unchecked_unpack(black_box(W), black_box(&packed), &mut unpacked) };
+            black_box(unpacked);
         });
     }
 

--- a/benches/bitpacking_cmp_cod.rs
+++ b/benches/bitpacking_cmp_cod.rs
@@ -3,6 +3,7 @@
 use divan::Bencher;
 use fastlanes::{BitPacking, BitPackingCompare, FastLanesComparable};
 use num_traits::FromPrimitive;
+use std::hint::black_box;
 
 fn main() {
     divan::main();
@@ -27,11 +28,12 @@ where
         unsafe {
             BitPackingCompare::unchecked_unpack_cmp(
                 W,
-                &packed,
+                black_box(&packed),
                 &mut unpacked,
                 |a, b| a == b,
-                value,
+                black_box(value),
             );
+            black_box(unpacked);
         };
     });
 }
@@ -48,8 +50,8 @@ fn bitpacking_cmp_seq<T: BitPacking + FromPrimitive + Copy>(bencher: Bencher) {
     let mut unpacked = [T::zero(); 1024];
 
     bencher.bench_local(|| {
-        unsafe { T::unchecked_unpack(W, &packed, &mut unpacked) };
-        collect_bool_cmp(&unpacked, &value)
+        unsafe { T::unchecked_unpack(W, black_box(&packed), &mut unpacked) };
+        black_box(collect_bool_cmp(&unpacked, black_box(&value)))
     });
 }
 
@@ -64,7 +66,8 @@ fn bitpacking_cmp_unpack<T: BitPacking + FromPrimitive + Copy>(bencher: Bencher)
     let mut unpacked = [T::zero(); 1024];
 
     bencher.bench_local(|| {
-        unsafe { T::unchecked_unpack(W, &packed, &mut unpacked) };
+        unsafe { T::unchecked_unpack(W, black_box(&packed), &mut unpacked) };
+        black_box(unpacked);
     });
 }
 

--- a/benches/delta.rs
+++ b/benches/delta.rs
@@ -1,5 +1,6 @@
 use arrayref::{array_mut_ref, array_ref};
-use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use std::hint::black_box;
 use std::mem::size_of;
 
 use fastlanes::{BitPacking, Delta, FastLanes, Transpose};

--- a/benches/delta.rs
+++ b/benches/delta.rs
@@ -1,5 +1,5 @@
 use arrayref::{array_mut_ref, array_ref};
-use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 use std::mem::size_of;
 
 use fastlanes::{BitPacking, Delta, FastLanes, Transpose};
@@ -28,16 +28,22 @@ fn delta(c: &mut Criterion) {
     group.bench_function("delta u16 fused", |b| {
         b.iter(|| {
             let mut unpacked = [0; 1024];
-            Delta::undelta_pack::<LANES, W, B>(&packed, &[0; 64], &mut unpacked);
+            Delta::undelta_pack::<LANES, W, B>(
+                black_box(&packed),
+                black_box(&[0; 64]),
+                &mut unpacked,
+            );
+            black_box(unpacked);
         });
     });
 
     group.bench_function("delta u16 unfused", |b| {
         b.iter(|| {
             let mut unpacked = [0; 1024];
-            BitPacking::unpack::<W, B>(&packed, &mut unpacked);
+            BitPacking::unpack::<W, B>(black_box(&packed), &mut unpacked);
             let mut undelta = [0; 1024];
-            Delta::undelta(&unpacked, &[0; 64], &mut undelta);
+            Delta::undelta(black_box(&unpacked), black_box(&[0; 64]), &mut undelta);
+            black_box(undelta);
         });
     });
 }
@@ -58,10 +64,11 @@ fn throughput(c: &mut Criterion) {
         b.iter(|| {
             for i in 0..NUM_BATCHES {
                 BitPacking::pack::<WIDTH, B>(
-                    array_ref![values, i * 1024, 1024],
+                    black_box(array_ref![values, i * 1024, 1024]),
                     array_mut_ref![packed, i * OUTPUT_BATCH_SIZE, OUTPUT_BATCH_SIZE],
                 );
             }
+            black_box(&packed);
         });
     });
 
@@ -69,10 +76,11 @@ fn throughput(c: &mut Criterion) {
         b.iter(|| {
             for i in 0..NUM_BATCHES {
                 BitPacking::unpack::<WIDTH, B>(
-                    array_ref![packed, i * OUTPUT_BATCH_SIZE, OUTPUT_BATCH_SIZE],
+                    black_box(array_ref![packed, i * OUTPUT_BATCH_SIZE, OUTPUT_BATCH_SIZE]),
                     array_mut_ref![values, i * 1024, 1024],
                 );
             }
+            black_box(&values);
         });
     });
 }

--- a/benches/rle.rs
+++ b/benches/rle.rs
@@ -1,5 +1,6 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use fastlanes::RLE;
+use std::hint::black_box;
 use std::mem::size_of;
 
 fn rle(c: &mut Criterion) {

--- a/benches/transpose.rs
+++ b/benches/transpose.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use fastlanes::Transpose;
 
@@ -11,7 +11,10 @@ fn transpose(c: &mut Criterion) {
         }
 
         let mut transposed = [0; 1024];
-        b.iter(|| Transpose::transpose(&values, &mut transposed));
+        b.iter(|| {
+            Transpose::transpose(black_box(&values), &mut transposed);
+            black_box(transposed);
+        });
     });
 }
 

--- a/benches/transpose.rs
+++ b/benches/transpose.rs
@@ -1,4 +1,5 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
 
 use fastlanes::Transpose;
 


### PR DESCRIPTION
This change black boxes input and output parameters for all fastlanes benchmarks where applicable.