### PR TITLE
fix: increase sample count to stabilize benchmarks

### DIFF
--- a/benches/bitpacking_cmp.rs
+++ b/benches/bitpacking_cmp.rs
@@ -41,7 +41,7 @@ mod bench {
         });
     }
 
-    #[divan::bench(types=[u8, u16, u32, u64], consts = BENCH_W)]
+    #[divan::bench(types=[u8, u16, u32, u64], consts = BENCH_W, sample_count = 10000)]
     fn bitpacking_cmp_seq<T, const W: usize>(bencher: Bencher)
     where
         T: BitPacking + FromPrimitive + Copy,
@@ -62,7 +62,7 @@ mod bench {
         });
     }
 
-    #[divan::bench(types=[u8, u16, u32, u64], consts = BENCH_W)]
+    #[divan::bench(types=[u8, u16, u32, u64], consts = BENCH_W, sample_count = 10000)]
     fn bitpacking_cmp_unpack<T, const W: usize>(bencher: Bencher)
     where
         T: BitPacking + FromPrimitive + Copy,

--- a/benches/bitpacking_cmp_cod.rs
+++ b/benches/bitpacking_cmp_cod.rs
@@ -38,7 +38,7 @@ where
     });
 }
 
-#[divan::bench(types=[u16, u32, u64])]
+#[divan::bench(types=[u16, u32, u64], sample_count = 10000)]
 fn bitpacking_cmp_seq<T: BitPacking + FromPrimitive + Copy>(bencher: Bencher) {
     const W: usize = 3;
     let value = T::from_usize(1).expect("");
@@ -55,7 +55,7 @@ fn bitpacking_cmp_seq<T: BitPacking + FromPrimitive + Copy>(bencher: Bencher) {
     });
 }
 
-#[divan::bench(types=[u16, u32, u64])]
+#[divan::bench(types=[u16, u32, u64], sample_count = 10000)]
 fn bitpacking_cmp_unpack<T: BitPacking + FromPrimitive + Copy>(bencher: Bencher) {
     const W: usize = 3;
     let values = [T::from_usize(2).expect(""); 1024];


### PR DESCRIPTION
Reproduced locally that increasing the sample count reduces the jitter between runs.