### PR TITLE
chore: switch to metal instance for ci benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
     name: Benchmark with Codspeed
     runs-on:
       - runs-on=${{ github.run_id }}
-      - image=ubuntu24-full-x64
       - family=c6a.metal
-      - spot=false
+      - image=ubuntu24-full-x64
+      - tag=bench-codspeed
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,12 @@ jobs:
 
   bench-codspeed:
     name: Benchmark with Codspeed
-    runs-on: ubuntu-latest
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - image=ubuntu24-full-x64
+      - family=c6a.metal
+      - spot=false
+
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: ./.github/actions/setup-rust


### PR DESCRIPTION
Switches the CI runner to `c6a.metal` in order to reduce jitter between benchmarks runs.