### PR TITLE
Benchmark fused comparison for all widths

### DIFF
--- a/benches/bitpacking_cmp.rs
+++ b/benches/bitpacking_cmp.rs
@@ -13,24 +13,34 @@ mod bench {
 
     const BENCH_W: [usize; 4] = [2, 3, 5, 7];
 
-    #[divan::bench(types=[u8, u16, u32, u64], consts = BENCH_W)]
-    fn bitpacking_cmp_fused<T, const W: usize>(bencher: Bencher)
+    const ALL_WIDTHS: [usize; 62] = [
+        2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
+        27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+        50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
+    ];
+
+    #[divan::bench(types=[u8, u16, u32, u64], args=ALL_WIDTHS)]
+    fn bitpacking_cmp_fused<T>(bencher: Bencher, width: usize)
     where
         T: BitPacking + FastLanesComparable<Bitpacked = T> + FromPrimitive + Copy,
         T: BitPacking + BitPackingCompare + Copy,
     {
         let value = T::from_usize(1).expect("");
         let values = [T::from_usize(2).expect(""); 1024];
-        let mut packed = vec![T::zero(); 128 * W / size_of::<T>()];
+        let mut packed = vec![T::zero(); 128 * width / size_of::<T>()];
 
-        unsafe { BitPacking::unchecked_pack(W, &values, &mut packed) };
+        if width >= T::T {
+            return;
+        }
+
+        unsafe { BitPacking::unchecked_pack(width, &values, &mut packed) };
 
         let mut unpacked = [false; 1024];
 
         bencher.bench_local(|| {
             unsafe {
                 BitPackingCompare::unchecked_unpack_cmp(
-                    black_box(W),
+                    black_box(width),
                     black_box(&packed),
                     &mut unpacked,
                     |a, b| a == b,

--- a/benches/bitpacking_cmp.rs
+++ b/benches/bitpacking_cmp.rs
@@ -4,7 +4,6 @@ fn main() {
     divan::main();
 }
 
-#[cfg(not(codspeed))]
 mod bench {
     use divan::Bencher;
     use fastlanes::{BitPacking, BitPackingCompare, FastLanesComparable};


### PR DESCRIPTION
Enable fused comparison benchmarking, and run it for all widths