### PR TITLE
Bump toolchain to stable and MSRV to 1.91 while verifying MSRV respected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,21 @@ jobs:
       - name: Rust Test
         run: cargo test --workspace --all-features
 
+  msrv:
+    name: MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-rust
+
+      - name: Install cargo-msrv
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-msrv
+
+      - name: Verify MSRV
+        run: cargo msrv verify
+
   bench-codspeed:
     name: Benchmark with Codspeed
     runs-on:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/spiraldb/fastlanes"
 authors = ["SpiralDB <hello@spiraldb.com>"]
 keywords = ["fastlanes", "compression", "codec"]
 edition = "2021"
+rust-version = "1.91"
 
 [dependencies]
 arrayref = "0.3.7"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.88.0"
+channel = "stable"
 components = ["rust-src", "rustfmt", "clippy"]
 profile = "minimal"

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -1,7 +1,6 @@
 #![allow(unused_assignments)]
 
 use crate::{iterate, supported_bit_width, unpack, BitPacking, FastLanes};
-use paste::paste;
 
 pub trait Delta: BitPacking {
     fn delta<const LANES: usize>(


### PR DESCRIPTION
No reason to settle for an old compiler if we can just keep making sure the MSRV is respected (but also for #125)