### PR TITLE
Add fused delta(for(bitpacking)) decode kernel (unstable)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,11 @@ num-traits = "0.2.19"
 paste = "1.0.15"
 seq-macro = "0.3.5"
 
+[features]
+# Unstable kernels with no semver stability guarantee yet. Currently gates the fused
+# `Delta::unfor_undelta_pack` decode for delta(for(bitpacking)) stacks.
+unstable = []
+
 [dev-dependencies]
 arrayref = "0.3.9"
 divan = { package = "codspeed-divan-compat", version = "4.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ paste = "1.0.15"
 seq-macro = "0.3.5"
 
 [features]
-# Unstable kernels with no semver stability guarantee yet. Currently gates the fused
-# `Delta::unfor_undelta_pack` decode for delta(for(bitpacking)) stacks.
-unstable = []
+# Gates the fused `Delta::unfor_undelta_pack` decode for delta(for(bitpacking)) stacks.
+# No semver stability guarantee yet.
+delta_for_bitpacking = []
 
 [dev-dependencies]
 arrayref = "0.3.9"

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -1,9 +1,13 @@
 #![allow(unused_assignments)]
 
+#[cfg(feature = "unstable")]
 use arrayref::{array_mut_ref, array_ref};
+#[cfg(feature = "unstable")]
 use paste::paste;
 
-use crate::{iterate, seq_t, supported_bit_width, unpack, BitPacking, FastLanes};
+#[cfg(feature = "unstable")]
+use crate::seq_t;
+use crate::{iterate, supported_bit_width, unpack, BitPacking, FastLanes};
 
 pub trait Delta: BitPacking {
     fn delta<const LANES: usize>(
@@ -30,6 +34,9 @@ pub trait Delta: BitPacking {
     /// frame-of-reference `reference` (inverting `FoR`), then accumulates the result against the
     /// running per-lane `base` (inverting delta encoding). This fuses what would otherwise be three
     /// passes — `unpack`, `unfor`, and `undelta` — into one, avoiding two intermediate buffers.
+    ///
+    /// Available only with the `unstable` feature; the API is not yet covered by semver guarantees.
+    #[cfg(feature = "unstable")]
     fn unfor_undelta_pack<const LANES: usize, const W: usize, const B: usize>(
         input: &[Self; B],
         reference: Self,
@@ -44,6 +51,9 @@ pub trait Delta: BitPacking {
     /// `input` must have length `1024 * width / T` (where `T` is the bit-width of `Self`), `base`
     /// must have length `Self::LANES`, and `output` must have length exactly 1024. These lengths are
     /// checked only with `debug_assert` (i.e., not checked on release builds).
+    ///
+    /// Available only with the `unstable` feature; the API is not yet covered by semver guarantees.
+    #[cfg(feature = "unstable")]
     unsafe fn unchecked_unfor_undelta_pack(
         width: usize,
         input: &[Self],
@@ -117,6 +127,7 @@ macro_rules! impl_delta {
                 }
             }
 
+            #[cfg(feature = "unstable")]
             #[inline(never)]
             fn unfor_undelta_pack<const LANES: usize, const W: usize, const B: usize>(
                 input: &[Self; B],
@@ -140,6 +151,7 @@ macro_rules! impl_delta {
                 }
             }
 
+            #[cfg(feature = "unstable")]
             unsafe fn unchecked_unfor_undelta_pack(
                 width: usize,
                 input: &[Self],
@@ -228,6 +240,7 @@ mod test {
         assert_eq!(transposed, undelta);
     }
 
+    #[cfg(feature = "unstable")]
     #[test]
     fn test_unfor_undelta() {
         const LANES: usize = u16::LANES;

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -1,11 +1,11 @@
 #![allow(unused_assignments)]
 
-#[cfg(feature = "unstable")]
+#[cfg(feature = "delta_for_bitpacking")]
 use arrayref::{array_mut_ref, array_ref};
-#[cfg(feature = "unstable")]
+#[cfg(feature = "delta_for_bitpacking")]
 use paste::paste;
 
-#[cfg(feature = "unstable")]
+#[cfg(feature = "delta_for_bitpacking")]
 use crate::seq_t;
 use crate::{iterate, supported_bit_width, unpack, BitPacking, FastLanes};
 
@@ -35,8 +35,8 @@ pub trait Delta: BitPacking {
     /// running per-lane `base` (inverting delta encoding). This fuses what would otherwise be three
     /// passes — `unpack`, `unfor`, and `undelta` — into one, avoiding two intermediate buffers.
     ///
-    /// Available only with the `unstable` feature; the API is not yet covered by semver guarantees.
-    #[cfg(feature = "unstable")]
+    /// Available only with the `delta_for_bitpacking` feature; the API is not yet covered by semver guarantees.
+    #[cfg(feature = "delta_for_bitpacking")]
     fn unfor_undelta_pack<const LANES: usize, const W: usize, const B: usize>(
         input: &[Self; B],
         reference: Self,
@@ -52,8 +52,8 @@ pub trait Delta: BitPacking {
     /// must have length `Self::LANES`, and `output` must have length exactly 1024. These lengths are
     /// checked only with `debug_assert` (i.e., not checked on release builds).
     ///
-    /// Available only with the `unstable` feature; the API is not yet covered by semver guarantees.
-    #[cfg(feature = "unstable")]
+    /// Available only with the `delta_for_bitpacking` feature; the API is not yet covered by semver guarantees.
+    #[cfg(feature = "delta_for_bitpacking")]
     unsafe fn unchecked_unfor_undelta_pack(
         width: usize,
         input: &[Self],
@@ -127,7 +127,7 @@ macro_rules! impl_delta {
                 }
             }
 
-            #[cfg(feature = "unstable")]
+            #[cfg(feature = "delta_for_bitpacking")]
             #[inline(never)]
             fn unfor_undelta_pack<const LANES: usize, const W: usize, const B: usize>(
                 input: &[Self; B],
@@ -151,7 +151,7 @@ macro_rules! impl_delta {
                 }
             }
 
-            #[cfg(feature = "unstable")]
+            #[cfg(feature = "delta_for_bitpacking")]
             unsafe fn unchecked_unfor_undelta_pack(
                 width: usize,
                 input: &[Self],
@@ -240,7 +240,7 @@ mod test {
         assert_eq!(transposed, undelta);
     }
 
-    #[cfg(feature = "unstable")]
+    #[cfg(feature = "delta_for_bitpacking")]
     #[test]
     fn test_unfor_undelta() {
         const LANES: usize = u16::LANES;

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -1,6 +1,9 @@
 #![allow(unused_assignments)]
 
-use crate::{iterate, supported_bit_width, unpack, BitPacking, FastLanes};
+use arrayref::{array_mut_ref, array_ref};
+use paste::paste;
+
+use crate::{iterate, seq_t, supported_bit_width, unpack, BitPacking, FastLanes};
 
 pub trait Delta: BitPacking {
     fn delta<const LANES: usize>(
@@ -19,6 +22,34 @@ pub trait Delta: BitPacking {
         input: &[Self; B],
         base: &[Self; LANES],
         output: &mut [Self; 1024],
+    );
+
+    /// Fused decode of a `delta(for(bitpacking))` stack.
+    ///
+    /// In a single pass over the `W`-bit packed `input`, this unpacks each lane, wrapping-adds the
+    /// frame-of-reference `reference` (inverting `FoR`), then accumulates the result against the
+    /// running per-lane `base` (inverting delta encoding). This fuses what would otherwise be three
+    /// passes — `unpack`, `unfor`, and `undelta` — into one, avoiding two intermediate buffers.
+    fn unfor_undelta_pack<const LANES: usize, const W: usize, const B: usize>(
+        input: &[Self; B],
+        reference: Self,
+        base: &[Self; LANES],
+        output: &mut [Self; 1024],
+    );
+
+    /// Fused decode of a `delta(for(bitpacking))` stack where the packed width `W` is only known at
+    /// runtime. Dispatches to [`Delta::unfor_undelta_pack`] for the matching compile-time width.
+    ///
+    /// # Safety
+    /// `input` must have length `1024 * width / T` (where `T` is the bit-width of `Self`), `base`
+    /// must have length `Self::LANES`, and `output` must have length exactly 1024. These lengths are
+    /// checked only with `debug_assert` (i.e., not checked on release builds).
+    unsafe fn unchecked_unfor_undelta_pack(
+        width: usize,
+        input: &[Self],
+        reference: Self,
+        base: &[Self],
+        output: &mut [Self],
     );
 }
 
@@ -85,6 +116,71 @@ macro_rules! impl_delta {
                     });
                 }
             }
+
+            #[inline(never)]
+            fn unfor_undelta_pack<const LANES: usize, const W: usize, const B: usize>(
+                input: &[Self; B],
+                reference: Self,
+                base: &[Self; LANES],
+                output: &mut [Self; 1024],
+            ) {
+                const {
+                    assert!(LANES == Self::LANES);
+                    assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
+                    assert!(B == 1024 * W / Self::T);
+                }
+
+                for lane in 0..Self::LANES {
+                    let mut prev = base[lane];
+                    unpack!($T, W, input, lane, |$idx, $elem| {
+                        let next = $elem.wrapping_add(reference).wrapping_add(prev);
+                        output[$idx] = next;
+                        prev = next;
+                    });
+                }
+            }
+
+            unsafe fn unchecked_unfor_undelta_pack(
+                width: usize,
+                input: &[Self],
+                reference: Self,
+                base: &[Self],
+                output: &mut [Self],
+            ) {
+                const LANES: usize = <$T>::LANES;
+                let packed_len = 128 * width / size_of::<Self>();
+                debug_assert_eq!(input.len(), packed_len, "Input buffer must be of size 1024 * W / T");
+                debug_assert_eq!(output.len(), 1024, "Output buffer must be of size 1024");
+                debug_assert_eq!(base.len(), LANES, "Base buffer must be of size LANES");
+                debug_assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
+
+                let base = array_ref![base, 0, LANES];
+                paste!(seq_t!(W in $T {
+                    match width {
+                        #(W => {
+                            const B: usize = 1024 * W / <$T>::T;
+                            Self::unfor_undelta_pack::<LANES, W, B>(
+                                array_ref![input, 0, B],
+                                reference,
+                                base,
+                                array_mut_ref![output, 0, 1024],
+                            )
+                        },)*
+                        // seq_t has exclusive upper bound
+                        Self::T => {
+                            const W: usize = <$T>::T;
+                            const B: usize = 1024;
+                            Self::unfor_undelta_pack::<LANES, W, B>(
+                                array_ref![input, 0, 1024],
+                                reference,
+                                base,
+                                array_mut_ref![output, 0, 1024],
+                            )
+                        },
+                        _ => unreachable!("Unsupported width: {}", width)
+                    }
+                }))
+            }
         }
     };
 }
@@ -130,5 +226,44 @@ mod test {
         let mut undelta = [0; 1024];
         Delta::undelta(&unpacked, &[0; 64], &mut undelta);
         assert_eq!(transposed, undelta);
+    }
+
+    #[test]
+    fn test_unfor_undelta() {
+        const LANES: usize = u16::LANES;
+        const W: usize = 9;
+        const B: usize = 1024 * W / u16::T;
+        const REFERENCE: u16 = 5;
+
+        // Arbitrary FoR-encoded deltas that fit in W bits.
+        let mut for_deltas: [u16; 1024] = [0; 1024];
+        for i in 0..1024 {
+            for_deltas[i] = (i % (1 << W)) as u16;
+        }
+
+        let base = [11u16; LANES];
+
+        // Independently reconstruct the expected output: FoR-decode (add reference) then undelta.
+        let mut deltas = [0u16; 1024];
+        for i in 0..1024 {
+            deltas[i] = for_deltas[i].wrapping_add(REFERENCE);
+        }
+        let mut expected = [0u16; 1024];
+        Delta::undelta::<LANES>(&deltas, &base, &mut expected);
+
+        // Bit-pack the FoR-encoded deltas and decode them with the fused kernel.
+        let mut packed = [0; 128 * W / size_of::<u16>()];
+        BitPacking::pack::<W, B>(&for_deltas, &mut packed);
+
+        let mut unpacked = [0u16; 1024];
+        Delta::unfor_undelta_pack::<LANES, W, B>(&packed, REFERENCE, &base, &mut unpacked);
+        assert_eq!(expected, unpacked);
+
+        // The runtime-width dispatch must agree with the const-generic kernel.
+        let mut unpacked_dyn = [0u16; 1024];
+        unsafe {
+            Delta::unchecked_unfor_undelta_pack(W, &packed, REFERENCE, &base, &mut unpacked_dyn);
+        }
+        assert_eq!(expected, unpacked_dyn);
     }
 }


### PR DESCRIPTION
## Summary

Adds a fused decode kernel for a `delta(for(bitpacking))` stack, gated behind a new default-off `delta_for_bitpacking` feature.

`Delta::unfor_undelta_pack::<LANES, W, B>` decodes in a **single pass** over the `W`-bit packed buffer: for each lane it unpacks, wrapping-adds the frame-of-reference (inverting FoR), then accumulates against the running per-lane base (inverting delta). This fuses what were three passes — `unpack` → `unfor` → `undelta` — and removes two intermediate buffers. A runtime-width dispatcher `unchecked_unfor_undelta_pack` selects the compile-time `W` (same pattern as `FoR::unchecked_unfor_pack`). It reuses the existing `unpack!` macro, so it inherits the transposed-iteration ordering that makes delta fusion correct.

## Feature flag

Both trait methods, their macro impls, and the test live behind `[features] delta_for_bitpacking = []` (off by default), because the kernel is monomorphized across every `(type × bit-width)` and that has a real `.text` cost (below). Downstream (Vortex) turns it on via its own `unstable_encodings` feature.

## Tests

`test_unfor_undelta` round-trips both the const-generic kernel and the runtime-width dispatcher against an independent `undelta`-of-FoR-decoded reference. `cargo test --features delta_for_bitpacking`, `cargo clippy --features delta_for_bitpacking --all-targets`, and the default (feature-off) `cargo clippy` + `cargo fmt --check` are all clean. Real CI here (Build / MSRV / Benchmark) is green.

## Code-size analysis

Release `libfastlanes` rlib (`nm --print-size`, summing `t`/`T` symbols):

| feature | new symbols | new `.text` |
|---|---|---|
| `delta_for_bitpacking` **off** (default) | 0 | **0 B** |
| `delta_for_bitpacking` **on** | 128 | **~254 KiB** |

128 = 124 width-specialized `unfor_undelta_pack` (9 u8 + 17 u16 + 33 u32 + 65 u64) + 4 `unchecked_` dispatchers. Comparable to the existing `unfor_pack` family (128 / ~224 KiB). Behind a default-off feature, it costs nothing unless enabled.

## Performance — is the kernel optimal? (asm + A/B, measured locally)

**The kernel is at parity with the shipped kernels.** Microbench (best-of-30, same chunk), u32 W=11: `unfor_undelta_pack` 0.156 vs `undelta_pack` 0.153 vs `unfor_pack` 0.152 ns/elem — within noise. The fused FoR-add + undelta-add fold into the existing `vpaddd` chain for free.

**Wider SIMD does not help — it regresses normal widths:**

| ns/elem | SSE2 | AVX2 | AVX-512 |
|---|---|---|---|
| fused u32 W=11 | **0.156** | 0.172 | 0.172 |
| fused u64 W=17 | **0.374** | 0.415 | 0.416 |
| fused u32 W=1 | 0.157 | 0.124 | **0.119** |

Asm confirms the AVX2 build is *clean* (163 insns vs SSE2's 195, full `%ymm`, **zero cross-lane shuffles**) yet ~10% slower — it's shift/mask/add port-throughput + AVX frequency-bound, not codegen quality. Only the degenerate W=1 (trivial unpack → pure stores) benefits. So a hand-written intrinsic kernel can't beat LLVM's SSE2 autovectorization here. The real win is the **fusion**, not kernel micro-optimization (see the Vortex PR for end-to-end numbers).

🤖 Generated with [Claude Code](https://claude.ai/code)