### PR TITLE
Fused bitpacking compare into a 1024-bit mask (+ SIMD bit-untranspose)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ std = []
 [dependencies]
 arrayref = "0.3.7"
 const_for = "0.1.4"
+core_detect = "1.0.0"
 num-traits = "0.2.19"
 paste = "1.0.15"
 seq-macro = "0.3.5"

--- a/benches/bit_transpose.rs
+++ b/benches/bit_transpose.rs
@@ -4,6 +4,7 @@ use arrayref::array_mut_ref;
 use arrayref::array_ref;
 use divan::counter::BytesCount;
 use divan::Bencher;
+use fastlanes::FastLanes;
 
 fn main() {
     divan::main();
@@ -40,9 +41,12 @@ fn scalar_transpose(bencher: Bencher) {
     bench_blocks(bencher, fastlanes::scalar::transpose_bits);
 }
 
-#[divan::bench]
-fn scalar_untranspose(bencher: Bencher) {
-    bench_blocks(bencher, fastlanes::scalar::untranspose_bits);
+/// Untranspose is generic over the element width `T`; benchmark each width separately. The mask
+/// always factors into 16 groups of 8 bytes regardless of `T`, so per-arch the widths should be
+/// within noise of one another (only the gather/scatter index tables differ).
+#[divan::bench(types = [u8, u16, u32, u64])]
+fn scalar_untranspose<T: FastLanes>(bencher: Bencher) {
+    bench_blocks(bencher, fastlanes::scalar::untranspose_bits::<T>);
 }
 
 #[divan::bench]
@@ -50,9 +54,9 @@ fn dispatch_transpose(bencher: Bencher) {
     bench_blocks(bencher, fastlanes::transpose_bits);
 }
 
-#[divan::bench]
-fn dispatch_untranspose(bencher: Bencher) {
-    bench_blocks(bencher, fastlanes::untranspose_bits);
+#[divan::bench(types = [u8, u16, u32, u64])]
+fn dispatch_untranspose<T: FastLanes>(bencher: Bencher) {
+    bench_blocks(bencher, fastlanes::untranspose_bits::<T>);
 }
 
 #[cfg(target_arch = "x86_64")]
@@ -101,6 +105,7 @@ mod x86 {
 mod aarch64 {
     use super::{bench_blocks, Bencher};
     use fastlanes::aarch64;
+    use fastlanes::FastLanes;
 
     #[divan::bench]
     fn neon_transpose(bencher: Bencher) {
@@ -110,11 +115,11 @@ mod aarch64 {
         });
     }
 
-    #[divan::bench]
-    fn neon_untranspose(bencher: Bencher) {
+    #[divan::bench(types = [u8, u16, u32, u64])]
+    fn neon_untranspose<T: FastLanes>(bencher: Bencher) {
         // SAFETY: NEON is always available on aarch64.
         bench_blocks(bencher, |i, o| unsafe {
-            aarch64::untranspose_bits_neon(i, o)
+            aarch64::untranspose_bits_neon::<T>(i, o)
         });
     }
 }

--- a/benches/bitpacking_cmp.rs
+++ b/benches/bitpacking_cmp.rs
@@ -6,86 +6,114 @@ fn main() {
 
 mod bench {
     use divan::Bencher;
-    use fastlanes::{BitPacking, BitPackingCompare, FastLanesComparable};
+    use fastlanes::{
+        transpose_bits, untranspose_bits, BitPacking, BitPackingCompare, FastLanes,
+        FastLanesComparable,
+    };
     use num_traits::FromPrimitive;
     use std::hint::black_box;
 
-    const BENCH_W: [usize; 4] = [2, 3, 5, 7];
-
-    const ALL_WIDTHS: [usize; 62] = [
-        2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
-        27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
-        50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
+    const ALL_WIDTHS: [usize; 63] = [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+        26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
+        49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
     ];
 
-    #[divan::bench(types=[u8, u16, u32, u64], args=ALL_WIDTHS)]
-    fn bitpacking_cmp_fused<T>(bencher: Bencher, width: usize)
+    /// Baseline: unpack into a `[T; 1024]` scratch buffer, then compare into a `[u64; 16]` bitmask
+    /// in logical row order (arrow-rs `collect_bool` style).
+    #[divan::bench(types=[u8, u16, u32, u64], args=ALL_WIDTHS, sample_count = 2000)]
+    fn cmp_seq<T>(bencher: Bencher, width: usize)
     where
-        T: BitPacking + FastLanesComparable<Bitpacked = T> + FromPrimitive + Copy,
-        T: BitPacking + BitPackingCompare + Copy,
+        T: BitPacking + FromPrimitive + Copy + PartialEq,
     {
-        let value = T::from_usize(1).expect("");
-        let values = [T::from_usize(2).expect(""); 1024];
-        let mut packed = vec![T::zero(); 128 * width / size_of::<T>()];
-
         if width >= T::T {
             return;
         }
-
-        unsafe { BitPacking::unchecked_pack(width, &values, &mut packed) };
-
-        let mut unpacked = [false; 1024];
-
-        bencher.bench_local(|| {
-            unsafe {
-                BitPackingCompare::unchecked_unpack_cmp(
-                    black_box(width),
-                    black_box(&packed),
-                    &mut unpacked,
-                    |a, b| a == b,
-                    black_box(value),
-                );
-                black_box(&unpacked);
-            };
-        });
-    }
-
-    #[divan::bench(types=[u8, u16, u32, u64], consts = BENCH_W, sample_count = 10000)]
-    fn bitpacking_cmp_seq<T, const W: usize>(bencher: Bencher)
-    where
-        T: BitPacking + FromPrimitive + Copy,
-    {
         let value = T::from_usize(1).expect("");
         let values = [T::from_usize(2).expect(""); 1024];
-        let mut packed = vec![T::zero(); 128 * W / size_of::<T>()];
-
-        unsafe { T::unchecked_pack(W, &values, &mut packed) };
+        let mut packed = vec![T::zero(); 128 * width / size_of::<T>()];
+        unsafe { T::unchecked_pack(width, &values, &mut packed) };
 
         let mut unpacked = [T::zero(); 1024];
         let mut bools = [0u64; 16];
 
         bencher.bench_local(|| {
-            unsafe { T::unchecked_unpack(black_box(W), black_box(&packed), &mut unpacked) };
+            unsafe { T::unchecked_unpack(black_box(width), black_box(&packed), &mut unpacked) };
             collect_bool_cmp(&unpacked, black_box(&value), black_box(&mut bools));
             black_box(&bools);
         });
     }
 
-    #[divan::bench(types=[u8, u16, u32, u64], consts = BENCH_W, sample_count = 10000)]
-    fn bitpacking_cmp_unpack<T, const W: usize>(bencher: Bencher)
+    /// Fused unpack+compare straight into a transposed `[u64; 16]` bitmask (`FastLanes` order). No
+    /// intermediate buffer, no untranspose.
+    #[divan::bench(types=[u8, u16, u32, u64], args=ALL_WIDTHS, sample_count = 2000)]
+    fn cmp_fused_transposed<T>(bencher: Bencher, width: usize)
     where
-        T: BitPacking + FromPrimitive + Copy,
+        T: BitPacking
+            + BitPackingCompare
+            + FastLanesComparable<Bitpacked = T>
+            + FromPrimitive
+            + Copy,
     {
+        if width >= T::T {
+            return;
+        }
+        let value = T::from_usize(1).expect("");
         let values = [T::from_usize(2).expect(""); 1024];
-        let mut packed = vec![T::zero(); 128 * W / size_of::<T>()];
+        let mut packed = vec![T::zero(); 128 * width / size_of::<T>()];
+        unsafe { T::unchecked_pack(width, &values, &mut packed) };
 
-        unsafe { T::unchecked_pack(W, &values, &mut packed) };
-
-        let mut unpacked = [T::zero(); 1024];
+        let mut output = [0u64; 16];
 
         bencher.bench_local(|| {
-            unsafe { T::unchecked_unpack(black_box(W), black_box(&packed), &mut unpacked) };
-            black_box(&unpacked);
+            unsafe {
+                T::unchecked_unpack_cmp(
+                    black_box(width),
+                    black_box(&packed),
+                    &mut output,
+                    |a, b| a == b,
+                    black_box(value),
+                );
+            }
+            black_box(&output);
+        });
+    }
+
+    /// Full drop-in for `cmp_seq`: fused compare into a transposed mask, then bit-untranspose into
+    /// logical row order. Identical output to unpack-then-`collect_bool`.
+    #[divan::bench(types=[u8, u16, u32, u64], args=ALL_WIDTHS, sample_count = 2000)]
+    fn cmp_fused_untranspose<T>(bencher: Bencher, width: usize)
+    where
+        T: BitPacking
+            + BitPackingCompare
+            + FastLanes
+            + FastLanesComparable<Bitpacked = T>
+            + FromPrimitive
+            + Copy,
+    {
+        if width >= T::T {
+            return;
+        }
+        let value = T::from_usize(1).expect("");
+        let values = [T::from_usize(2).expect(""); 1024];
+        let mut packed = vec![T::zero(); 128 * width / size_of::<T>()];
+        unsafe { T::unchecked_pack(width, &values, &mut packed) };
+
+        let mut transposed = [0u64; 16];
+        let mut logical = [0u64; 16];
+
+        bencher.bench_local(|| {
+            unsafe {
+                T::unchecked_unpack_cmp(
+                    black_box(width),
+                    black_box(&packed),
+                    &mut transposed,
+                    |a, b| a == b,
+                    black_box(value),
+                );
+            }
+            untranspose_bits(black_box(&transposed), &mut logical);
+            black_box(&logical);
         });
     }
 
@@ -105,8 +133,6 @@ mod bench {
                 let i = bit_idx + chunk * 64;
                 packed |= u64::from(f(i)) << bit_idx;
             }
-
-            // SAFETY: Already allocated sufficient capacity
             output[chunk] = packed;
         }
     }

--- a/benches/bitpacking_cmp.rs
+++ b/benches/bitpacking_cmp.rs
@@ -18,70 +18,10 @@ mod bench {
         49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
     ];
 
-    /// Baseline: unpack into a `[T; 1024]` scratch buffer, then compare into a `[u64; 16]` bitmask
-    /// in logical row order (arrow-rs `collect_bool` style).
-    #[divan::bench(types=[u8, u16, u32, u64], args=ALL_WIDTHS, sample_count = 2000)]
-    fn cmp_seq<T>(bencher: Bencher, width: usize)
-    where
-        T: BitPacking + FromPrimitive + Copy + PartialEq,
-    {
-        if width >= T::T {
-            return;
-        }
-        let value = T::from_usize(1).expect("");
-        let values = [T::from_usize(2).expect(""); 1024];
-        let mut packed = vec![T::zero(); 128 * width / size_of::<T>()];
-        unsafe { T::unchecked_pack(width, &values, &mut packed) };
-
-        let mut unpacked = [T::zero(); 1024];
-        let mut bools = [0u64; 16];
-
-        bencher.bench_local(|| {
-            unsafe { T::unchecked_unpack(black_box(width), black_box(&packed), &mut unpacked) };
-            collect_bool_cmp(&unpacked, black_box(&value), black_box(&mut bools));
-            black_box(&bools);
-        });
-    }
-
-    /// Fused unpack+compare straight into a transposed `[u64; 16]` bitmask (`FastLanes` order). No
-    /// intermediate buffer, no untranspose.
-    #[divan::bench(types=[u8, u16, u32, u64], args=ALL_WIDTHS, sample_count = 2000)]
-    fn cmp_fused_transposed<T>(bencher: Bencher, width: usize)
-    where
-        T: BitPacking
-            + BitPackingCompare
-            + FastLanesComparable<Bitpacked = T>
-            + FromPrimitive
-            + Copy,
-    {
-        if width >= T::T {
-            return;
-        }
-        let value = T::from_usize(1).expect("");
-        let values = [T::from_usize(2).expect(""); 1024];
-        let mut packed = vec![T::zero(); 128 * width / size_of::<T>()];
-        unsafe { T::unchecked_pack(width, &values, &mut packed) };
-
-        let mut output = [0u64; 16];
-
-        bencher.bench_local(|| {
-            unsafe {
-                T::unchecked_unpack_cmp(
-                    black_box(width),
-                    black_box(&packed),
-                    &mut output,
-                    |a, b| a == b,
-                    black_box(value),
-                );
-            }
-            black_box(&output);
-        });
-    }
-
     /// Full drop-in for `cmp_seq`: fused compare into a transposed mask, then bit-untranspose into
     /// logical row order. Identical output to unpack-then-`collect_bool`.
     #[divan::bench(types=[u8, u16, u32, u64], args=ALL_WIDTHS, sample_count = 2000)]
-    fn cmp_fused_untranspose<T>(bencher: Bencher, width: usize)
+    fn cmp_fused<T>(bencher: Bencher, width: usize)
     where
         T: BitPacking
             + BitPackingCompare
@@ -114,25 +54,5 @@ mod bench {
             untranspose_bits::<T>(black_box(&transposed), &mut logical);
             black_box(&logical);
         });
-    }
-
-    pub fn collect_bool_cmp<T: PartialEq + Copy>(
-        unpacked: &[T; 1024],
-        cmp: &T,
-        output: &mut [u64; 16],
-    ) {
-        collect_bool(|idx| unpacked[idx] == *cmp, output);
-    }
-
-    #[inline]
-    pub fn collect_bool<F: FnMut(usize) -> bool>(mut f: F, output: &mut [u64; 16]) {
-        for chunk in 0..16 {
-            let mut packed = 0;
-            for bit_idx in 0..64 {
-                let i = bit_idx + chunk * 64;
-                packed |= u64::from(f(i)) << bit_idx;
-            }
-            output[chunk] = packed;
-        }
     }
 }

--- a/benches/bitpacking_cmp.rs
+++ b/benches/bitpacking_cmp.rs
@@ -7,8 +7,7 @@ fn main() {
 mod bench {
     use divan::Bencher;
     use fastlanes::{
-        transpose_bits, untranspose_bits, BitPacking, BitPackingCompare, FastLanes,
-        FastLanesComparable,
+        untranspose_bits, BitPacking, BitPackingCompare, FastLanes, FastLanesComparable,
     };
     use num_traits::FromPrimitive;
     use std::hint::black_box;
@@ -112,7 +111,7 @@ mod bench {
                     black_box(value),
                 );
             }
-            untranspose_bits(black_box(&transposed), &mut logical);
+            untranspose_bits::<T>(black_box(&transposed), &mut logical);
             black_box(&logical);
         });
     }

--- a/src/bit_transpose/aarch64.rs
+++ b/src/bit_transpose/aarch64.rs
@@ -1,11 +1,10 @@
 //! `AArch64` NEON transpose implementation using TBL-based gather/scatter.
-#![cfg(target_arch = "aarch64")]
 
 use core::arch::aarch64::uint64x2_t;
 use core::arch::aarch64::vandq_u64;
 use core::arch::aarch64::vdupq_n_u64;
+use core::arch::aarch64::vdupq_n_u8;
 use core::arch::aarch64::veorq_u64;
-use core::arch::aarch64::vgetq_lane_u64;
 use core::arch::aarch64::vld1q_u8;
 use core::arch::aarch64::vld1q_u8_x4;
 use core::arch::aarch64::vorrq_u8;
@@ -15,14 +14,15 @@ use core::arch::aarch64::vreinterpretq_u8_u64;
 use core::arch::aarch64::vshlq_n_u64;
 use core::arch::aarch64::vshrq_n_u64;
 use core::arch::aarch64::vst1q_u8;
+use core::arch::aarch64::vsubq_u8;
 
 use crate::bit_transpose::as_byte_array;
 use crate::bit_transpose::as_byte_array_mut;
-use crate::bit_transpose::BASE_PATTERN_FIRST;
-use crate::bit_transpose::BASE_PATTERN_SECOND;
 use crate::bit_transpose::TRANSPOSE_2X2;
 use crate::bit_transpose::TRANSPOSE_4X4;
 use crate::bit_transpose::TRANSPOSE_8X8;
+use crate::FastLanes;
+use crate::FL_ORDER;
 
 /// Gather indices for the first half from input[0..64] (low 4 bytes of each group).
 static GATHER_FIRST_LO: [[u8; 16]; 4] = [
@@ -172,44 +172,113 @@ pub unsafe fn transpose_bits_neon(input: &[u64; 16], output: &mut [u64; 16]) {
     }
 }
 
-/// Untranspose one 1024-bit block using NEON with TBL-based gather and scatter.
+/// Byte-gather indices that pull the 8 bytes of every group into contiguous group-major order
+/// for an element width of `tb` bits. Group `g = lhi * (tb/8) + hi` collects byte `llo` of its
+/// lane words from input byte `lhi*tb + hi + llo*(tb/8)`. See [`crate::scalar::untranspose_bits`].
+const fn gather_indices(tb: usize) -> [u8; 128] {
+    let bytes = tb / 8;
+    let mut idx = [0u8; 128];
+    let mut g = 0;
+    while g < 16 {
+        let lhi = g / bytes;
+        let hi = g % bytes;
+        let gather_base = lhi * tb + hi;
+        let mut llo = 0;
+        while llo < 8 {
+            idx[g * 8 + llo] = (gather_base + llo * bytes) as u8;
+            llo += 1;
+        }
+        g += 1;
+    }
+    idx
+}
+
+/// Byte-scatter indices applied after the per-group 8x8 transpose: transposed byte `g*8 + lo`
+/// lands at logical byte `FL_ORDER[hi]*2 + lhi + lo*16`. Expressed as a gather table for
+/// [`permute_128`]: `idx[logical_byte] = g*8 + lo`.
+const fn scatter_indices(tb: usize) -> [u8; 128] {
+    let bytes = tb / 8;
+    let mut idx = [0u8; 128];
+    let mut g = 0;
+    while g < 16 {
+        let lhi = g / bytes;
+        let hi = g % bytes;
+        let scatter_base = FL_ORDER[hi] * 2 + lhi;
+        let mut lo = 0;
+        while lo < 8 {
+            idx[scatter_base + lo * 16] = (g * 8 + lo) as u8;
+            lo += 1;
+        }
+        g += 1;
+    }
+    idx
+}
+
+static GATHER_8: [u8; 128] = gather_indices(8);
+static GATHER_16: [u8; 128] = gather_indices(16);
+static GATHER_32: [u8; 128] = gather_indices(32);
+static GATHER_64: [u8; 128] = gather_indices(64);
+
+static SCATTER_8: [u8; 128] = scatter_indices(8);
+static SCATTER_16: [u8; 128] = scatter_indices(16);
+static SCATTER_32: [u8; 128] = scatter_indices(32);
+static SCATTER_64: [u8; 128] = scatter_indices(64);
+
+/// Apply an arbitrary 128-byte gather permutation (`out[k] = src[idx[k]]`) using NEON TBL.
+///
+/// `vqtbl4q_u8` only addresses 64 source bytes, returning 0 for indices `>= 64`. We split `src`
+/// into its low and high 64 bytes and OR the two table lookups: high indices select from `hi`
+/// (after subtracting 64), low indices wrap past 64 in the `hi` lookup and so contribute 0.
+#[inline]
+#[allow(unsafe_op_in_unsafe_fn)]
+unsafe fn permute_128(src: &[u8; 128], idx: &[u8; 128]) -> [u8; 128] {
+    let lo = vld1q_u8_x4(src.as_ptr());
+    let hi = vld1q_u8_x4(src.as_ptr().add(64));
+    let bias = vdupq_n_u8(64);
+
+    let mut out = [0u8; 128];
+    for k in 0..8 {
+        let want = vld1q_u8(idx.as_ptr().add(k * 16));
+        let want_hi = vsubq_u8(want, bias);
+        let from_lo = vqtbl4q_u8(lo, want);
+        let from_hi = vqtbl4q_u8(hi, want_hi);
+        vst1q_u8(out.as_mut_ptr().add(k * 16), vorrq_u8(from_lo, from_hi));
+    }
+    out
+}
+
+/// Untranspose a `T`-width comparison mask into logical row order using NEON.
+///
+/// Regardless of width the 128 bytes factor into 16 groups of 8 bytes, each an independent 8x8
+/// bit transpose (see [`crate::scalar::untranspose_bits`]). We TBL-gather the groups into
+/// group-major order, run the per-group 8x8 transpose, then TBL-scatter to logical positions.
 ///
 /// # Safety
 /// Requires `AArch64` with NEON (always available on `AArch64`).
 #[inline]
 #[allow(unsafe_op_in_unsafe_fn)]
-pub unsafe fn untranspose_bits_neon(input: &[u64; 16], output: &mut [u64; 16]) {
-    let input = as_byte_array(input);
-    let output = as_byte_array_mut(output);
+pub unsafe fn untranspose_bits_neon<T: FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
+    let (gather_idx, scatter_idx): (&[u8; 128], &[u8; 128]) = match T::T {
+        8 => (&GATHER_8, &SCATTER_8),
+        16 => (&GATHER_16, &SCATTER_16),
+        32 => (&GATHER_32, &SCATTER_32),
+        _ => (&GATHER_64, &SCATTER_64),
+    };
 
-    let scatter0 = vld1q_u8(SCATTER_8X8_NEON[0].as_ptr());
-    let scatter1 = vld1q_u8(SCATTER_8X8_NEON[1].as_ptr());
-    let scatter2 = vld1q_u8(SCATTER_8X8_NEON[2].as_ptr());
-    let scatter3 = vld1q_u8(SCATTER_8X8_NEON[3].as_ptr());
+    // Gather the 16 groups into contiguous group-major order.
+    let gathered = permute_128(as_byte_array(input), gather_idx);
 
-    let mut buf = [0u8; 64];
-    for (i, base_pattern) in [BASE_PATTERN_FIRST, BASE_PATTERN_SECOND].iter().enumerate() {
-        let in_tbl = vld1q_u8_x4(input.as_ptr().add(i * 64));
-        vst1q_u8(buf.as_mut_ptr(), vqtbl4q_u8(in_tbl, scatter0));
-        vst1q_u8(buf.as_mut_ptr().add(16), vqtbl4q_u8(in_tbl, scatter1));
-        vst1q_u8(buf.as_mut_ptr().add(32), vqtbl4q_u8(in_tbl, scatter2));
-        vst1q_u8(buf.as_mut_ptr().add(48), vqtbl4q_u8(in_tbl, scatter3));
-
-        for pair in 0..4 {
-            let gathered = vld1q_u8(buf.as_ptr().add(pair * 16));
-            let v = bit_transpose_8x8_neon(vreinterpretq_u64_u8(gathered));
-
-            let result_0 = vgetq_lane_u64::<0>(v);
-            let result_1 = vgetq_lane_u64::<1>(v);
-
-            let out_base_0 = base_pattern[pair * 2];
-            let out_base_1 = base_pattern[pair * 2 + 1];
-            for row in 0..8 {
-                output[out_base_0 + row * 16] = (result_0 >> (row * 8)) as u8;
-                output[out_base_1 + row * 16] = (result_1 >> (row * 8)) as u8;
-            }
-        }
+    // 8x8 bit-transpose each group; a `uint64x2_t` covers two consecutive groups (16 bytes).
+    let mut transposed = [0u8; 128];
+    for r in 0..8 {
+        let v = bit_transpose_8x8_neon(vreinterpretq_u64_u8(vld1q_u8(
+            gathered.as_ptr().add(r * 16),
+        )));
+        vst1q_u8(transposed.as_mut_ptr().add(r * 16), vreinterpretq_u8_u64(v));
     }
+
+    // Scatter the transposed groups to their logical byte positions.
+    *as_byte_array_mut(output) = permute_128(&transposed, scatter_idx);
 }
 
 #[cfg(test)]
@@ -247,7 +316,7 @@ mod tests {
             // SAFETY: NEON is always available on aarch64.
             unsafe {
                 transpose_bits_neon(&input, &mut transposed);
-                untranspose_bits_neon(&transposed, &mut roundtrip);
+                untranspose_bits_neon::<u64>(&transposed, &mut roundtrip);
             }
 
             assert_eq!(input, roundtrip, "NEON roundtrip failed for seed {seed}");
@@ -261,14 +330,42 @@ mod tests {
             let mut baseline_out = [0u64; 16];
             let mut tbl_out = [0u64; 16];
 
-            untranspose_bits_baseline(&input, &mut baseline_out);
+            untranspose_bits_baseline::<u64>(&input, &mut baseline_out);
             // SAFETY: NEON is always available on aarch64.
-            unsafe { untranspose_bits_neon(&input, &mut tbl_out) };
+            unsafe { untranspose_bits_neon::<u64>(&input, &mut tbl_out) };
 
             assert_eq!(
                 baseline_out, tbl_out,
                 "NEON untranspose doesn't match baseline for seed {seed}"
             );
         }
+    }
+
+    /// The generic NEON untranspose must match the width-parameterized baseline for every
+    /// element width.
+    #[test]
+    fn test_untranspose_neon_all_widths_match_baseline() {
+        fn check<T: FastLanes>() {
+            for seed in [0, 42, 123, 255] {
+                let input = generate_test_data(seed);
+                let mut baseline_out = [0u64; 16];
+                let mut tbl_out = [0u64; 16];
+
+                untranspose_bits_baseline::<T>(&input, &mut baseline_out);
+                // SAFETY: NEON is always available on aarch64.
+                unsafe { untranspose_bits_neon::<T>(&input, &mut tbl_out) };
+
+                assert_eq!(
+                    baseline_out,
+                    tbl_out,
+                    "NEON untranspose != baseline for type={} seed={seed}",
+                    core::any::type_name::<T>()
+                );
+            }
+        }
+        check::<u8>();
+        check::<u16>();
+        check::<u32>();
+        check::<u64>();
     }
 }

--- a/src/bit_transpose/mod.rs
+++ b/src/bit_transpose/mod.rs
@@ -120,34 +120,42 @@ pub fn transpose_bits(input: &[u64; 16], output: &mut [u64; 16]) {
     #[cfg(target_arch = "aarch64")]
     // SAFETY: NEON is always available on aarch64.
     unsafe {
-        aarch64::transpose_bits_neon(input, output)
+        aarch64::transpose_bits_neon(input, output);
     }
     #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
     scalar::transpose_bits(input, output);
 }
 
-/// Untranspose 1024 bits from `FastLanes` layout, dispatching to the best implementation.
+/// Untranspose a `T`-width comparison mask (1024 bits) from `FastLanes` layout into logical row
+/// order, dispatching to the best implementation. For `T = u64` this is the canonical `FastLanes`
+/// bit untranspose; narrower `T` undo the per-lane packing produced by `unpack_cmp` for that width.
 #[inline]
-pub fn untranspose_bits(input: &[u64; 16], output: &mut [u64; 16]) {
+pub fn untranspose_bits<T: crate::FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
     #[cfg(target_arch = "x86_64")]
     {
-        if detect_vbmi() {
+        // The BMI2/VBMI kernels currently only implement the `u64` (16-lane) transpose; other
+        // widths fall back to scalar.
+        //
+        // TODO(x86): add width-generic `untranspose_bits_{bmi2,vbmi}::<T>` kernels (mirroring the
+        // NEON `permute_128` + per-group 8x8 transpose approach in `aarch64.rs`) and route u8/u16/
+        // u32 through them here instead of the scalar fallback.
+        if T::T == 64 && detect_vbmi() {
             // SAFETY: guarded by `detect_vbmi`.
             unsafe { x86::untranspose_bits_vbmi(input, output) }
-        } else if detect_bmi2() {
+        } else if T::T == 64 && detect_bmi2() {
             // SAFETY: guarded by `detect_bmi2`.
             unsafe { x86::untranspose_bits_bmi2(input, output) }
         } else {
-            scalar::untranspose_bits(input, output);
+            scalar::untranspose_bits::<T>(input, output);
         }
     }
     #[cfg(target_arch = "aarch64")]
     // SAFETY: NEON is always available on aarch64.
     unsafe {
-        aarch64::untranspose_bits_neon(input, output)
+        aarch64::untranspose_bits_neon::<T>(input, output);
     }
     #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
-    scalar::untranspose_bits(input, output);
+    scalar::untranspose_bits::<T>(input, output);
 }
 
 #[cfg(test)]
@@ -172,16 +180,25 @@ pub(crate) fn transpose_bits_baseline(input: &[u64; 16], output: &mut [u64; 16])
     }
 }
 
-/// Reference untranspose: the inverse permutation of [`transpose_bits_baseline`].
+/// Reference untranspose for a `T`-width comparison mask, one bit at a time.
+///
+/// Mask bit `b = lane * T::T + row` holds the comparison for logical index `index(row, lane)`
+/// (the `unpack!` macro's formula), so we scatter each mask bit to its logical position. For
+/// `T = u64` this is exactly the inverse permutation of [`transpose_bits_baseline`].
 #[cfg(test)]
-pub(crate) fn untranspose_bits_baseline(input: &[u64; 16], output: &mut [u64; 16]) {
+pub(crate) fn untranspose_bits_baseline<T: crate::FastLanes>(
+    input: &[u64; 16],
+    output: &mut [u64; 16],
+) {
     let input = as_byte_array(input);
     let output = as_byte_array_mut(output);
     *output = [0u8; 128];
-    for out_bit in 0..1024 {
-        let in_bit = crate::transpose(out_bit);
-        let bit_val = (input[in_bit / 8] >> (in_bit % 8)) & 1;
-        output[out_bit / 8] |= bit_val << (out_bit % 8);
+    for b in 0..1024 {
+        let lane = b / T::T;
+        let row = b % T::T;
+        let logical = crate::FL_ORDER[row / 8] * 16 + (row % 8) * 128 + lane;
+        let bit_val = (input[b / 8] >> (b % 8)) & 1;
+        output[logical / 8] |= bit_val << (logical % 8);
     }
 }
 
@@ -196,7 +213,7 @@ mod tests {
         let mut roundtrip = [0u64; 16];
 
         transpose_bits_baseline(&input, &mut transposed);
-        untranspose_bits_baseline(&transposed, &mut roundtrip);
+        untranspose_bits_baseline::<u64>(&transposed, &mut roundtrip);
 
         assert_eq!(input, roundtrip);
     }
@@ -225,8 +242,8 @@ mod tests {
             let mut baseline_out = [0u64; 16];
             let mut out = [0u64; 16];
 
-            untranspose_bits_baseline(&input, &mut baseline_out);
-            untranspose_bits(&input, &mut out);
+            untranspose_bits_baseline::<u64>(&input, &mut baseline_out);
+            untranspose_bits::<u64>(&input, &mut out);
 
             assert_eq!(
                 baseline_out, out,
@@ -243,7 +260,7 @@ mod tests {
             let mut roundtrip = [0u64; 16];
 
             transpose_bits(&input, &mut transposed);
-            untranspose_bits(&transposed, &mut roundtrip);
+            untranspose_bits::<u64>(&transposed, &mut roundtrip);
 
             assert_eq!(
                 input, roundtrip,

--- a/src/bit_transpose/scalar.rs
+++ b/src/bit_transpose/scalar.rs
@@ -179,7 +179,8 @@ mod tests {
                 untranspose_bits::<T>(&input, &mut scalar_out);
 
                 assert_eq!(
-                    baseline_out, scalar_out,
+                    baseline_out,
+                    scalar_out,
                     "scalar untranspose != baseline for type={} seed={seed}",
                     core::any::type_name::<T>()
                 );

--- a/src/bit_transpose/scalar.rs
+++ b/src/bit_transpose/scalar.rs
@@ -13,6 +13,8 @@ use crate::bit_transpose::BASE_PATTERN_SECOND;
 use crate::bit_transpose::TRANSPOSE_2X2;
 use crate::bit_transpose::TRANSPOSE_4X4;
 use crate::bit_transpose::TRANSPOSE_8X8;
+use crate::FastLanes;
+use crate::FL_ORDER;
 
 /// The two halves of the `FastLanes` byte-group ordering.
 const HALVES: [[usize; 8]; 2] = [BASE_PATTERN_FIRST, BASE_PATTERN_SECOND];
@@ -64,19 +66,39 @@ pub fn transpose_bits(input: &[u64; 16], output: &mut [u64; 16]) {
     }
 }
 
-/// Untranspose one 1024-bit block using the scalar implementation.
+/// Untranspose a `T`-width comparison mask into logical row order, scalar implementation.
+///
+/// The mask produced by `unpack_cmp` for an element width of `T::T` bits is laid out as
+/// `T::LANES` words of `T::T` bits (LSB-first per lane); the bit at position
+/// `lane * T::T + row` holds the comparison for logical index `index(row, lane)` (see the
+/// `unpack!` macro). This is the inverse of that permutation.
+///
+/// Regardless of width the 128 bytes always factor into exactly 16 groups of 8 bytes, each
+/// group being an independent 8x8 bit transpose. The width only changes which input bytes form
+/// a group (the gather stride) and where the transposed bytes land (the scatter base). For
+/// `T = u64` this reduces to the canonical `FastLanes` bit untranspose.
 #[inline]
-pub fn untranspose_bits(input: &[u64; 16], output: &mut [u64; 16]) {
+pub fn untranspose_bits<T: FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
     let input = as_byte_array(input);
     let output = as_byte_array_mut(output);
-    for (half, groups) in HALVES.iter().enumerate() {
-        for (group, &base) in groups.iter().enumerate() {
-            // Gather the 8 consecutive bytes of this group from the transposed layout.
+
+    // `bytes` = bytes per lane word (T::T / 8); `lhi_count` = lanes / 8 (= 128 / T::T). Their
+    // product is always 16 groups.
+    let bytes = T::T / 8;
+    let lhi_count = 128 / T::T;
+    for lhi in 0..lhi_count {
+        for hi in 0..bytes {
+            // Gather the 8 bytes of group `(lhi, hi)`: byte `llo` of the lane word for the lanes
+            // sharing this group sits at stride `bytes`.
+            let gather_base = lhi * T::T + hi;
             let mut packed = 0u64;
-            for bit in 0..8 {
-                packed |= u64::from(input[half * 64 + bit * 8 + group]) << (bit * 8);
+            for llo in 0..8 {
+                packed |= u64::from(input[gather_base + llo * bytes]) << (llo * 8);
             }
-            scatter(output, base, transpose_8x8(packed));
+            // After the 8x8 transpose the byte index is the comparison row's low bits, scattered
+            // at stride 16; the FL_ORDER permutation of `hi` picks the base byte.
+            let scatter_base = FL_ORDER[hi] * 2 + lhi;
+            scatter(output, scatter_base, transpose_8x8(packed));
         }
     }
 }
@@ -86,6 +108,7 @@ mod tests {
     use super::*;
     use crate::bit_transpose::generate_test_data;
     use crate::bit_transpose::transpose_bits_baseline;
+    use crate::bit_transpose::untranspose_bits_baseline;
 
     #[test]
     fn test_scalar_matches_baseline() {
@@ -112,7 +135,7 @@ mod tests {
             let mut roundtrip = [0u64; 16];
 
             transpose_bits(&input, &mut transposed);
-            untranspose_bits(&transposed, &mut roundtrip);
+            untranspose_bits::<u64>(&transposed, &mut roundtrip);
 
             assert_eq!(input, roundtrip, "scalar roundtrip failed for seed {seed}");
         }
@@ -126,7 +149,7 @@ mod tests {
         transpose_bits(&input, &mut output);
         assert_eq!(output, [0u64; 16]);
 
-        untranspose_bits(&input, &mut output);
+        untranspose_bits::<u64>(&input, &mut output);
         assert_eq!(output, [0u64; 16]);
     }
 
@@ -138,7 +161,33 @@ mod tests {
         transpose_bits(&input, &mut output);
         assert_eq!(output, [u64::MAX; 16]);
 
-        untranspose_bits(&input, &mut output);
+        untranspose_bits::<u64>(&input, &mut output);
         assert_eq!(output, [u64::MAX; 16]);
+    }
+
+    /// The generic untranspose must match the width-parameterized baseline for every element
+    /// width, not just `u64`.
+    #[test]
+    fn test_untranspose_all_widths_match_baseline() {
+        fn check<T: FastLanes>() {
+            for seed in [0, 42, 123, 255] {
+                let input = generate_test_data(seed);
+                let mut baseline_out = [0u64; 16];
+                let mut scalar_out = [0u64; 16];
+
+                untranspose_bits_baseline::<T>(&input, &mut baseline_out);
+                untranspose_bits::<T>(&input, &mut scalar_out);
+
+                assert_eq!(
+                    baseline_out, scalar_out,
+                    "scalar untranspose != baseline for type={} seed={seed}",
+                    core::any::type_name::<T>()
+                );
+            }
+        }
+        check::<u8>();
+        check::<u16>();
+        check::<u32>();
+        check::<u64>();
     }
 }

--- a/src/bitpacking_cmp.rs
+++ b/src/bitpacking_cmp.rs
@@ -76,9 +76,10 @@ macro_rules! impl_packing_compare {
                 // a single contiguous (vectorizable) write per lane -- no `[bool; 1024]`
                 // (or `[Self; 1024]`) materialization, no cross-lane shuffles.
                 //
-                // LSB-first ordering makes the per-lane words coincide with the canonical FastLanes
-                // transpose for `u64` (`Self::LANES == 16`), so [`untranspose_cmp_mask`] can reuse
-                // the fast SIMD [`crate::bit_transpose::untranspose_bits`] there.
+                // For `u64` (`Self::LANES == 16`) this LSB-first ordering coincides with the
+                // canonical FastLanes transpose; for narrower widths it is the per-width packing
+                // that [`crate::bit_transpose::untranspose_bits::<Self>`] inverts. Either way that
+                // is what [`untranspose_cmp_mask`] uses to recover logical row order.
                 //
                 // SAFETY: `[u64; 16]` and `[Self; LANES]` are both exactly 128 bytes, and `u64`'s
                 // alignment (8) is >= `Self`'s alignment, so the reinterpret is sound.
@@ -245,7 +246,7 @@ mod tests {
                     // Untransposing the mask must yield logical row order: bit `i` is the
                     // comparison for logical value `i` (i.e. `collect_bool` semantics).
                     let mut logical = [0u64; 16];
-                    untranspose_bits(&output, &mut logical);
+                    untranspose_bits::<T>(&output, &mut logical);
                     let mut expected_logical = [0u64; 16];
                     for i in 0..1024 {
                         if f(T::as_unpacked(unpacked[i]), other) {

--- a/src/bitpacking_cmp.rs
+++ b/src/bitpacking_cmp.rs
@@ -4,29 +4,45 @@ use crate::{supported_bit_width, FastLanes, FastLanesComparable};
 use paste::paste;
 
 pub trait BitPackingCompare: FastLanes {
-    /// A fused unpack (see `BitPacking::unpack`) and compare and pack into bit bools.
-    /// This will compare using the comparison function all the packed values with a constant value,
-    /// the values are of type `Self`, whereas the comparison is on the type `V` (where `V::Bitpacked` = `Self`).
-    /// This allows for comparison between signed values which are bitpacked as unsigned ones.
+    /// A fused unpack (see `BitPacking::unpack`) and compare, packing the boolean results into a
+    /// bitmask of `1024` bits (`16 x u64`).
+    ///
+    /// This compares, using the comparison function, all of the packed values against a constant
+    /// `value`. The values are of type `Self`, whereas the comparison is on the type `V` (where
+    /// `V::Bitpacked` = `Self`). This allows for comparison between signed values which are
+    /// bit-packed as unsigned ones.
+    ///
+    /// The output is a bitmask in **`FastLanes` (transposed) order**, not logical row order. The
+    /// `1024` bits are `Self::LANES` words of `Self::T` bits, one word per lane laid out
+    /// contiguously (little-endian) in the `[u64; 16]`. Within a lane's word the comparison
+    /// results are packed LSB-first: row `r` (for `r` in `0..Self::T`) lands at bit `r`, holding
+    /// the comparison for the value at logical index `index(row, lane)` (see the `unpack!` macro).
+    /// This is the cheapest order to produce: it needs no cross-lane shuffles, just a per-lane
+    /// accumulator that the compiler keeps in a (vectorized) register.
+    ///
+    /// To recover logical row order (e.g. an Arrow-style boolean buffer), pass the result through
+    /// [`untranspose_cmp_mask`].
     fn unpack_cmp<const W: usize, const B: usize, V, F>(
         input: &[Self; B],
-        output: &mut [bool; 1024],
+        output: &mut [u64; 16],
         comparison: F,
         value: V,
     ) where
         V: FastLanesComparable<Bitpacked = Self>,
         F: Fn(V, V) -> bool;
 
-    /// A fused unpack (see `BitPacking::unpack`) and compare and pack into bit bools.
+    /// A fused unpack (see `BitPacking::unpack`) and compare, packing the boolean results into a
+    /// bitmask of `1024` bits (`16 x u64`). See [`BitPackingCompare::unpack_cmp`] for the output
+    /// bit ordering.
     ///
     /// # Safety
     /// The input slice must be of length `1024 * W / T`, where `T` is the bit-width of Self and `W`
-    /// is the packed width. The output slice must be of exactly length `[u64; 16]` (`1024` bits).
+    /// is the packed width. The output is exactly `[u64; 16]` (`1024` bits).
     /// These lengths are checked only with `debug_assert` (i.e., not checked on release builds).
     unsafe fn unchecked_unpack_cmp<V, F>(
         width: usize,
         input: &[Self],
-        output: &mut [bool; 1024],
+        output: &mut [u64; 16],
         comparison: F,
         value: V,
     ) where
@@ -40,7 +56,7 @@ macro_rules! impl_packing_compare {
             #[inline(never)]
             fn unpack_cmp<const W: usize, const B: usize, V, F>(
                 input: &[Self; B],
-                output: &mut [bool; 1024],
+                output: &mut [u64; 16],
                 f: F,
                 other: V,
             )
@@ -53,17 +69,39 @@ macro_rules! impl_packing_compare {
                     assert!(B == 1024 * W / Self::T);
                 }
 
-                for lane in (0..Self::LANES) {
+                // The output is 1024 bits laid out as `Self::LANES` words of `Self::T` bits each
+                // (which is always 128 bytes == `[u64; 16]`). Each lane owns one contiguous word
+                // holding that lane's `Self::T` comparison results, LSB-first: row `r` lands at bit
+                // `r`. Per-lane ownership means the accumulator stays in a register and the store is
+                // a single contiguous (vectorizable) write per lane -- no `[bool; 1024]`
+                // (or `[Self; 1024]`) materialization, no cross-lane shuffles.
+                //
+                // LSB-first ordering makes the per-lane words coincide with the canonical FastLanes
+                // transpose for `u64` (`Self::LANES == 16`), so [`untranspose_cmp_mask`] can reuse
+                // the fast SIMD [`crate::bit_transpose::untranspose_bits`] there.
+                //
+                // SAFETY: `[u64; 16]` and `[Self; LANES]` are both exactly 128 bytes, and `u64`'s
+                // alignment (8) is >= `Self`'s alignment, so the reinterpret is sound.
+                let words: &mut [$T; <$T>::LANES] =
+                    unsafe { &mut *output.as_mut_ptr().cast::<[$T; <$T>::LANES]>() };
+
+                for lane in 0..Self::LANES {
+                    let mut word: $T = 0;
+                    let mut bit: usize = 0;
                     unpack!($T, W, input, lane, |$idx, $elem| {
-                        output[$idx] = f(V::as_unpacked($elem), other);
+                        let _ = $idx;
+                        word |= <$T>::from(f(V::as_unpacked($elem), other)) << bit;
+                        #[allow(unused_assignments)]
+                        { bit += 1; }
                     });
+                    words[lane] = word;
                 }
             }
 
             unsafe fn unchecked_unpack_cmp<V, F>(
                  width: usize,
                  input: &[Self],
-                 output: &mut [bool; 1024],
+                 output: &mut [u64; 16],
                  comparison: F,
                  value: V,
             )
@@ -102,9 +140,36 @@ impl_packing_compare!(u64);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::BitPacking;
+    use crate::{untranspose_bits, BitPacking};
     use alloc::vec::Vec;
     use core::array;
+
+    /// Reference bitmask in the same `FastLanes` (LSB-first, per-lane) order produced by
+    /// `unpack_cmp`:
+    /// fully unpack, then for each lane set bit `row` from the comparison of the value at the
+    /// logical index `index(row, lane)`.
+    fn reference_mask<T, V, F>(packed_unpacked: &[T; 1024], f: F, other: V) -> [u64; 16]
+    where
+        T: FastLanes,
+        V: FastLanesComparable<Bitpacked = T>,
+        F: Fn(V, V) -> bool,
+    {
+        let mut out = [0u64; 16];
+        for lane in 0..T::LANES {
+            for row in 0..T::T {
+                // `index(row, lane)` from the unpack macro.
+                let o = row / 8;
+                let s = row % 8;
+                let idx = (crate::FL_ORDER[o] * 16) + (s * 128) + lane;
+                if f(V::as_unpacked(packed_unpacked[idx]), other) {
+                    // LSB-first within each lane word: row `r` lands at bit `r`.
+                    let bit = lane * T::T + row;
+                    out[bit / 64] |= 1u64 << (bit % 64);
+                }
+            }
+        }
+        out
+    }
 
     #[test]
     fn test_unpack_eq() {
@@ -117,17 +182,89 @@ mod tests {
         let mut packed = [0; (128 * W) / size_of::<T>()];
         T::pack::<W, B>(&values, &mut packed);
 
-        // Check equality against every value of the vector
+        let mut unpacked = [0u32; 1024];
+        T::unpack::<W, B>(&packed, &mut unpacked);
+
+        // Check equality against every value of the vector.
         for v in 0..1024 {
             let cmp = {
-                let mut output = [false; 1024];
+                let mut output = [0u64; 16];
                 T::unpack_cmp::<W, B, _, _>(&packed, &mut output, |a, b| a == b, v);
                 output
             };
 
-            let expected = values.iter().map(|&x| x == v).collect::<Vec<_>>();
-
-            assert_eq!(cmp.as_slice(), expected.as_slice(), "Failed == {v}");
+            let expected = reference_mask(&unpacked, |a, b| a == b, v);
+            assert_eq!(cmp, expected, "Failed == {v}");
         }
+    }
+
+    #[test]
+    fn test_unpack_cmp_all_widths_and_ops() {
+        fn check<T>()
+        where
+            T: BitPacking + BitPackingCompare + FastLanesComparable<Bitpacked = T>,
+        {
+            for width in 1..T::T {
+                let mask: u64 = if width == 64 {
+                    u64::MAX
+                } else {
+                    (1u64 << width) - 1
+                };
+                let values: [T; 1024] = array::from_fn(|i| {
+                    T::from((i as u64).wrapping_mul(2_654_435_761) & mask).unwrap()
+                });
+
+                let mut packed = Vec::new();
+                packed.resize(128 * width / size_of::<T>(), T::zero());
+                unsafe { T::unchecked_pack(width, &values, &mut packed) };
+
+                let mut unpacked = [T::zero(); 1024];
+                unsafe { T::unchecked_unpack(width, &packed, &mut unpacked) };
+
+                let other = T::from(7u64 & mask).unwrap();
+                for (name, f) in [
+                    ("eq", (|a: T, b: T| a == b) as fn(T, T) -> bool),
+                    ("ne", |a, b| a != b),
+                    ("lt", |a, b| a < b),
+                    ("le", |a, b| a <= b),
+                    ("gt", |a, b| a > b),
+                    ("ge", |a, b| a >= b),
+                ] {
+                    let mut output = [0u64; 16];
+                    unsafe {
+                        T::unchecked_unpack_cmp(width, &packed, &mut output, f, other);
+                    }
+                    let expected = reference_mask(&unpacked, f, other);
+                    assert_eq!(
+                        output,
+                        expected,
+                        "type={} width={width} op={name}",
+                        core::any::type_name::<T>()
+                    );
+
+                    // Untransposing the mask must yield logical row order: bit `i` is the
+                    // comparison for logical value `i` (i.e. `collect_bool` semantics).
+                    let mut logical = [0u64; 16];
+                    untranspose_bits(&output, &mut logical);
+                    let mut expected_logical = [0u64; 16];
+                    for i in 0..1024 {
+                        if f(T::as_unpacked(unpacked[i]), other) {
+                            expected_logical[i / 64] |= 1u64 << (i % 64);
+                        }
+                    }
+                    assert_eq!(
+                        logical,
+                        expected_logical,
+                        "untranspose type={} width={width} op={name}",
+                        core::any::type_name::<T>()
+                    );
+                }
+            }
+        }
+
+        check::<u8>();
+        check::<u16>();
+        check::<u32>();
+        check::<u64>();
     }
 }


### PR DESCRIPTION
## Summary

Reworks `BitPackingCompare::unpack_cmp` to fuse unpack + compare **straight into a `[u64; 16]` bitmask** (1024 bits) instead of materializing a `[bool; 1024]` byte-per-bool buffer.

### `unpack_cmp` — fused compare → transposed mask
Each lane accumulates its `T` comparison bits into one register-resident word and stores once (`LANES` stores total). No `[bool; 1024]`/`[T; 1024]` scratch, no second pass, no cross-lane shuffles. Output is a bitmask in **FastLanes (transposed) order**.
