### PR TITLE
Add FastLanes 1024-bit transpose with SIMD implementations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           RUSTFLAGS: "-C target-feature=+avx2"
         run: |
-          cargo codspeed build --profile bench
+          cargo codspeed build --profile bench --features std
 
       - name: Run benchmarks
         uses: CodSpeedHQ/action@3194d9a39c4d46684cb44bf7207fc56626aad8fd # v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,19 @@ license = "Apache-2.0"
 homepage = "https://github.com/spiraldb/fastlanes"
 repository = "https://github.com/spiraldb/fastlanes"
 authors = ["SpiralDB <hello@spiraldb.com>"]
+readme = "README.md"
 keywords = ["fastlanes", "compression", "codec", "encoding", "lightweight"]
+categories = ["compression"]
 edition = "2021"
 rust-version = "1.91"
 exclude = [".github/*", "renovate.json"]
+
+[features]
+default = []
+# Enables runtime CPU feature detection for `transpose_bits`/`untranspose_bits`
+# dispatch. Without it, the dispatch is resolved at compile time from the enabled
+# `target_feature`s, keeping the crate `no_std`.
+std = []
 
 [dependencies]
 arrayref = "0.3.7"
@@ -64,6 +73,11 @@ harness = false
 [[bench]]
 name = "transpose"
 harness = false
+
+[[bench]]
+name = "bit_transpose"
+harness = false
+required-features = ["std"]
 
 [[bench]]
 name = "rle"

--- a/benches/bit_transpose.rs
+++ b/benches/bit_transpose.rs
@@ -1,0 +1,120 @@
+use std::hint::black_box;
+
+use arrayref::array_mut_ref;
+use arrayref::array_ref;
+use divan::counter::BytesCount;
+use divan::Bencher;
+
+fn main() {
+    divan::main();
+}
+
+/// Number of 1024-bit blocks processed per benchmark iteration.
+/// 1024 blocks × 128 bytes = 128 KiB of input.
+const BLOCKS: usize = 1024;
+const U64S: usize = BLOCKS * 16;
+
+fn make_input() -> Vec<u64> {
+    (0..U64S as u64)
+        .map(|i| i.wrapping_mul(0x9E37_79B9_7F4A_7C15))
+        .collect()
+}
+
+/// Run `op` over every 1024-bit block of the buffer.
+fn bench_blocks(bencher: Bencher, op: impl Fn(&[u64; 16], &mut [u64; 16])) {
+    let input = make_input();
+    let mut output = vec![0u64; U64S];
+    bencher.counter(BytesCount::new(U64S * 8)).bench_local(|| {
+        for blk in 0..BLOCKS {
+            op(
+                array_ref!(input, blk * 16, 16),
+                array_mut_ref!(output, blk * 16, 16),
+            );
+        }
+        black_box(&output);
+    });
+}
+
+#[divan::bench]
+fn scalar_transpose(bencher: Bencher) {
+    bench_blocks(bencher, fastlanes::scalar::transpose_bits);
+}
+
+#[divan::bench]
+fn scalar_untranspose(bencher: Bencher) {
+    bench_blocks(bencher, fastlanes::scalar::untranspose_bits);
+}
+
+#[divan::bench]
+fn dispatch_transpose(bencher: Bencher) {
+    bench_blocks(bencher, fastlanes::transpose_bits);
+}
+
+#[divan::bench]
+fn dispatch_untranspose(bencher: Bencher) {
+    bench_blocks(bencher, fastlanes::untranspose_bits);
+}
+
+#[cfg(target_arch = "x86_64")]
+mod x86 {
+    use super::{bench_blocks, Bencher};
+    use fastlanes::x86;
+
+    #[divan::bench]
+    fn bmi2_transpose(bencher: Bencher) {
+        if !x86::has_bmi2() {
+            return;
+        }
+        // SAFETY: guarded by `has_bmi2`.
+        bench_blocks(bencher, |i, o| unsafe { x86::transpose_bits_bmi2(i, o) });
+    }
+
+    #[divan::bench]
+    fn bmi2_untranspose(bencher: Bencher) {
+        if !x86::has_bmi2() {
+            return;
+        }
+        // SAFETY: guarded by `has_bmi2`.
+        bench_blocks(bencher, |i, o| unsafe { x86::untranspose_bits_bmi2(i, o) });
+    }
+
+    #[divan::bench]
+    fn vbmi_transpose(bencher: Bencher) {
+        if !x86::has_vbmi() {
+            return;
+        }
+        // SAFETY: guarded by `has_vbmi`.
+        bench_blocks(bencher, |i, o| unsafe { x86::transpose_bits_vbmi(i, o) });
+    }
+
+    #[divan::bench]
+    fn vbmi_untranspose(bencher: Bencher) {
+        if !x86::has_vbmi() {
+            return;
+        }
+        // SAFETY: guarded by `has_vbmi`.
+        bench_blocks(bencher, |i, o| unsafe { x86::untranspose_bits_vbmi(i, o) });
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+mod aarch64 {
+    use super::{bench_blocks, Bencher};
+    use fastlanes::aarch64;
+
+    #[divan::bench]
+    fn neon_transpose(bencher: Bencher) {
+        // SAFETY: NEON is always available on aarch64.
+        bench_blocks(bencher, |i, o| unsafe {
+            aarch64::transpose_bits_neon(i, o)
+        });
+    }
+
+    #[divan::bench]
+    fn neon_untranspose(bencher: Bencher) {
+        // SAFETY: NEON is always available on aarch64.
+        bench_blocks(bencher, |i, o| unsafe {
+            aarch64::untranspose_bits_neon(i, o)
+        });
+    }
+}

--- a/src/bit_transpose/aarch64.rs
+++ b/src/bit_transpose/aarch64.rs
@@ -1,0 +1,274 @@
+//! `AArch64` NEON transpose implementation using TBL-based gather/scatter.
+#![cfg(target_arch = "aarch64")]
+
+use core::arch::aarch64::uint64x2_t;
+use core::arch::aarch64::vandq_u64;
+use core::arch::aarch64::vdupq_n_u64;
+use core::arch::aarch64::veorq_u64;
+use core::arch::aarch64::vgetq_lane_u64;
+use core::arch::aarch64::vld1q_u8;
+use core::arch::aarch64::vld1q_u8_x4;
+use core::arch::aarch64::vorrq_u8;
+use core::arch::aarch64::vqtbl4q_u8;
+use core::arch::aarch64::vreinterpretq_u64_u8;
+use core::arch::aarch64::vreinterpretq_u8_u64;
+use core::arch::aarch64::vshlq_n_u64;
+use core::arch::aarch64::vshrq_n_u64;
+use core::arch::aarch64::vst1q_u8;
+
+use crate::bit_transpose::as_byte_array;
+use crate::bit_transpose::as_byte_array_mut;
+use crate::bit_transpose::BASE_PATTERN_FIRST;
+use crate::bit_transpose::BASE_PATTERN_SECOND;
+use crate::bit_transpose::TRANSPOSE_2X2;
+use crate::bit_transpose::TRANSPOSE_4X4;
+use crate::bit_transpose::TRANSPOSE_8X8;
+
+/// Gather indices for the first half from input[0..64] (low 4 bytes of each group).
+static GATHER_FIRST_LO: [[u8; 16]; 4] = [
+    [
+        0, 16, 32, 48, 0xFF, 0xFF, 0xFF, 0xFF, 8, 24, 40, 56, 0xFF, 0xFF, 0xFF, 0xFF,
+    ],
+    [
+        4, 20, 36, 52, 0xFF, 0xFF, 0xFF, 0xFF, 12, 28, 44, 60, 0xFF, 0xFF, 0xFF, 0xFF,
+    ],
+    [
+        2, 18, 34, 50, 0xFF, 0xFF, 0xFF, 0xFF, 10, 26, 42, 58, 0xFF, 0xFF, 0xFF, 0xFF,
+    ],
+    [
+        6, 22, 38, 54, 0xFF, 0xFF, 0xFF, 0xFF, 14, 30, 46, 62, 0xFF, 0xFF, 0xFF, 0xFF,
+    ],
+];
+
+/// Gather indices for the first half from input[64..128] (high 4 bytes of each group).
+static GATHER_FIRST_HI: [[u8; 16]; 4] = [
+    [
+        0xFF, 0xFF, 0xFF, 0xFF, 0, 16, 32, 48, 0xFF, 0xFF, 0xFF, 0xFF, 8, 24, 40, 56,
+    ],
+    [
+        0xFF, 0xFF, 0xFF, 0xFF, 4, 20, 36, 52, 0xFF, 0xFF, 0xFF, 0xFF, 12, 28, 44, 60,
+    ],
+    [
+        0xFF, 0xFF, 0xFF, 0xFF, 2, 18, 34, 50, 0xFF, 0xFF, 0xFF, 0xFF, 10, 26, 42, 58,
+    ],
+    [
+        0xFF, 0xFF, 0xFF, 0xFF, 6, 22, 38, 54, 0xFF, 0xFF, 0xFF, 0xFF, 14, 30, 46, 62,
+    ],
+];
+
+/// Gather indices for the second half from input[0..64].
+static GATHER_SECOND_LO: [[u8; 16]; 4] = [
+    [
+        1, 17, 33, 49, 0xFF, 0xFF, 0xFF, 0xFF, 9, 25, 41, 57, 0xFF, 0xFF, 0xFF, 0xFF,
+    ],
+    [
+        5, 21, 37, 53, 0xFF, 0xFF, 0xFF, 0xFF, 13, 29, 45, 61, 0xFF, 0xFF, 0xFF, 0xFF,
+    ],
+    [
+        3, 19, 35, 51, 0xFF, 0xFF, 0xFF, 0xFF, 11, 27, 43, 59, 0xFF, 0xFF, 0xFF, 0xFF,
+    ],
+    [
+        7, 23, 39, 55, 0xFF, 0xFF, 0xFF, 0xFF, 15, 31, 47, 63, 0xFF, 0xFF, 0xFF, 0xFF,
+    ],
+];
+
+/// Gather indices for the second half from input[64..128].
+static GATHER_SECOND_HI: [[u8; 16]; 4] = [
+    [
+        0xFF, 0xFF, 0xFF, 0xFF, 1, 17, 33, 49, 0xFF, 0xFF, 0xFF, 0xFF, 9, 25, 41, 57,
+    ],
+    [
+        0xFF, 0xFF, 0xFF, 0xFF, 5, 21, 37, 53, 0xFF, 0xFF, 0xFF, 0xFF, 13, 29, 45, 61,
+    ],
+    [
+        0xFF, 0xFF, 0xFF, 0xFF, 3, 19, 35, 51, 0xFF, 0xFF, 0xFF, 0xFF, 11, 27, 43, 59,
+    ],
+    [
+        0xFF, 0xFF, 0xFF, 0xFF, 7, 23, 39, 55, 0xFF, 0xFF, 0xFF, 0xFF, 15, 31, 47, 63,
+    ],
+];
+
+/// 8x8 byte transpose (scatter) permutation split into 4 × 16-byte chunks for NEON TBL.
+/// Same permutation as x86 `SCATTER_8X8`, split for 16-byte NEON registers.
+static SCATTER_8X8_NEON: [[u8; 16]; 4] = [
+    [0, 8, 16, 24, 32, 40, 48, 56, 1, 9, 17, 25, 33, 41, 49, 57],
+    [2, 10, 18, 26, 34, 42, 50, 58, 3, 11, 19, 27, 35, 43, 51, 59],
+    [4, 12, 20, 28, 36, 44, 52, 60, 5, 13, 21, 29, 37, 45, 53, 61],
+    [6, 14, 22, 30, 38, 46, 54, 62, 7, 15, 23, 31, 39, 47, 55, 63],
+];
+
+/// Perform 8x8 bit transpose on two u64s packed in a `uint64x2_t`.
+#[inline]
+#[allow(unsafe_op_in_unsafe_fn)]
+unsafe fn bit_transpose_8x8_neon(mut v: uint64x2_t) -> uint64x2_t {
+    let mask1 = vdupq_n_u64(TRANSPOSE_2X2);
+    let t = vandq_u64(veorq_u64(v, vshrq_n_u64::<7>(v)), mask1);
+    v = veorq_u64(veorq_u64(v, t), vshlq_n_u64::<7>(t));
+
+    let mask2 = vdupq_n_u64(TRANSPOSE_4X4);
+    let t = vandq_u64(veorq_u64(v, vshrq_n_u64::<14>(v)), mask2);
+    v = veorq_u64(veorq_u64(v, t), vshlq_n_u64::<14>(t));
+
+    let mask3 = vdupq_n_u64(TRANSPOSE_8X8);
+    let t = vandq_u64(veorq_u64(v, vshrq_n_u64::<28>(v)), mask3);
+    veorq_u64(veorq_u64(v, t), vshlq_n_u64::<28>(t))
+}
+
+/// Transpose one 1024-bit block using NEON with TBL-based gather and scatter.
+///
+/// # Safety
+/// Requires `AArch64` with NEON (always available on `AArch64`).
+#[inline]
+#[allow(unsafe_op_in_unsafe_fn)]
+pub unsafe fn transpose_bits_neon(input: &[u64; 16], output: &mut [u64; 16]) {
+    let input = as_byte_array(input);
+    let output = as_byte_array_mut(output);
+
+    let tbl_lo = vld1q_u8_x4(input.as_ptr());
+    let tbl_hi = vld1q_u8_x4(input.as_ptr().add(64));
+
+    let scatter0 = vld1q_u8(SCATTER_8X8_NEON[0].as_ptr());
+    let scatter1 = vld1q_u8(SCATTER_8X8_NEON[1].as_ptr());
+    let scatter2 = vld1q_u8(SCATTER_8X8_NEON[2].as_ptr());
+    let scatter3 = vld1q_u8(SCATTER_8X8_NEON[3].as_ptr());
+
+    let mut buf = [0u8; 64];
+    for (i, (gather_lo, gather_high)) in [
+        (GATHER_FIRST_LO, GATHER_FIRST_HI),
+        (GATHER_SECOND_LO, GATHER_SECOND_HI),
+    ]
+    .iter()
+    .enumerate()
+    {
+        for pair in 0..4 {
+            let idx_lo = vld1q_u8(gather_lo[pair].as_ptr());
+            let idx_hi = vld1q_u8(gather_high[pair].as_ptr());
+
+            let from_lo = vqtbl4q_u8(tbl_lo, idx_lo);
+            let from_hi = vqtbl4q_u8(tbl_hi, idx_hi);
+            let gathered = vorrq_u8(from_lo, from_hi);
+
+            let v = bit_transpose_8x8_neon(vreinterpretq_u64_u8(gathered));
+            vst1q_u8(buf.as_mut_ptr().add(pair * 16), vreinterpretq_u8_u64(v));
+        }
+
+        let result_tbl = vld1q_u8_x4(buf.as_ptr());
+        vst1q_u8(
+            output.as_mut_ptr().add(i * 64),
+            vqtbl4q_u8(result_tbl, scatter0),
+        );
+        vst1q_u8(
+            output.as_mut_ptr().add(i * 64 + 16),
+            vqtbl4q_u8(result_tbl, scatter1),
+        );
+        vst1q_u8(
+            output.as_mut_ptr().add(i * 64 + 32),
+            vqtbl4q_u8(result_tbl, scatter2),
+        );
+        vst1q_u8(
+            output.as_mut_ptr().add(i * 64 + 48),
+            vqtbl4q_u8(result_tbl, scatter3),
+        );
+    }
+}
+
+/// Untranspose one 1024-bit block using NEON with TBL-based gather and scatter.
+///
+/// # Safety
+/// Requires `AArch64` with NEON (always available on `AArch64`).
+#[inline]
+#[allow(unsafe_op_in_unsafe_fn)]
+pub unsafe fn untranspose_bits_neon(input: &[u64; 16], output: &mut [u64; 16]) {
+    let input = as_byte_array(input);
+    let output = as_byte_array_mut(output);
+
+    let scatter0 = vld1q_u8(SCATTER_8X8_NEON[0].as_ptr());
+    let scatter1 = vld1q_u8(SCATTER_8X8_NEON[1].as_ptr());
+    let scatter2 = vld1q_u8(SCATTER_8X8_NEON[2].as_ptr());
+    let scatter3 = vld1q_u8(SCATTER_8X8_NEON[3].as_ptr());
+
+    let mut buf = [0u8; 64];
+    for (i, base_pattern) in [BASE_PATTERN_FIRST, BASE_PATTERN_SECOND].iter().enumerate() {
+        let in_tbl = vld1q_u8_x4(input.as_ptr().add(i * 64));
+        vst1q_u8(buf.as_mut_ptr(), vqtbl4q_u8(in_tbl, scatter0));
+        vst1q_u8(buf.as_mut_ptr().add(16), vqtbl4q_u8(in_tbl, scatter1));
+        vst1q_u8(buf.as_mut_ptr().add(32), vqtbl4q_u8(in_tbl, scatter2));
+        vst1q_u8(buf.as_mut_ptr().add(48), vqtbl4q_u8(in_tbl, scatter3));
+
+        for pair in 0..4 {
+            let gathered = vld1q_u8(buf.as_ptr().add(pair * 16));
+            let v = bit_transpose_8x8_neon(vreinterpretq_u64_u8(gathered));
+
+            let result_0 = vgetq_lane_u64::<0>(v);
+            let result_1 = vgetq_lane_u64::<1>(v);
+
+            let out_base_0 = base_pattern[pair * 2];
+            let out_base_1 = base_pattern[pair * 2 + 1];
+            for row in 0..8 {
+                output[out_base_0 + row * 16] = (result_0 >> (row * 8)) as u8;
+                output[out_base_1 + row * 16] = (result_1 >> (row * 8)) as u8;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bit_transpose::generate_test_data;
+    use crate::bit_transpose::transpose_bits_baseline;
+    use crate::bit_transpose::untranspose_bits_baseline;
+
+    #[test]
+    fn test_neon_matches_baseline() {
+        for seed in [0, 42, 123, 255] {
+            let input = generate_test_data(seed);
+            let mut baseline_out = [0u64; 16];
+            let mut tbl_out = [0u64; 16];
+
+            transpose_bits_baseline(&input, &mut baseline_out);
+            // SAFETY: NEON is always available on aarch64.
+            unsafe { transpose_bits_neon(&input, &mut tbl_out) };
+
+            assert_eq!(
+                baseline_out, tbl_out,
+                "NEON transpose doesn't match baseline for seed {seed}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_neon_roundtrip() {
+        for seed in [0, 42, 123, 255] {
+            let input = generate_test_data(seed);
+            let mut transposed = [0u64; 16];
+            let mut roundtrip = [0u64; 16];
+
+            // SAFETY: NEON is always available on aarch64.
+            unsafe {
+                transpose_bits_neon(&input, &mut transposed);
+                untranspose_bits_neon(&transposed, &mut roundtrip);
+            }
+
+            assert_eq!(input, roundtrip, "NEON roundtrip failed for seed {seed}");
+        }
+    }
+
+    #[test]
+    fn test_untranspose_neon_matches_baseline() {
+        for seed in [0, 42, 123, 255] {
+            let input = generate_test_data(seed);
+            let mut baseline_out = [0u64; 16];
+            let mut tbl_out = [0u64; 16];
+
+            untranspose_bits_baseline(&input, &mut baseline_out);
+            // SAFETY: NEON is always available on aarch64.
+            unsafe { untranspose_bits_neon(&input, &mut tbl_out) };
+
+            assert_eq!(
+                baseline_out, tbl_out,
+                "NEON untranspose doesn't match baseline for seed {seed}"
+            );
+        }
+    }
+}

--- a/src/bit_transpose/mod.rs
+++ b/src/bit_transpose/mod.rs
@@ -1,0 +1,254 @@
+//! Fast implementations of the `FastLanes` 1024-bit transpose.
+//!
+//! The `FastLanes` transpose is a fixed permutation of 1024 bits (16 × `u64`,
+//! i.e. 128 bytes) that enables SIMD parallelism for encodings like delta and
+//! RLE, and for transposing validity bitmaps. This module provides architecture
+//! specific implementations of both the transpose and its inverse.
+//!
+//! The key insight is that each output byte is formed by extracting the SAME bit
+//! position from 8 different input bytes at stride 16. The input byte groups follow
+//! the [`crate::FL_ORDER`] permutation pattern.
+//!
+//! # Choosing an implementation
+//!
+//! [`transpose_bits`] / [`untranspose_bits`] dispatch to the fastest available
+//! implementation. When the crate is built with the `std` feature this dispatch
+//! is performed at runtime via CPU feature detection; otherwise it is resolved at
+//! compile time from the enabled `target_feature`s, falling back to the portable
+//! scalar implementation.
+//!
+//! Every implementation is also exposed directly so that a downstream crate can
+//! select one explicitly even in a `no_std` build: [`scalar`], [`x86`]
+//! (`bmi2` / `avx512vbmi`), and [`aarch64`] (`neon`).
+//!
+//! All entry points operate over `[u64; 16]` (one 1024-bit block); bytes are
+//! interpreted in little-endian order.
+
+pub mod scalar;
+
+#[cfg(target_arch = "x86_64")]
+pub mod x86;
+
+#[cfg(target_arch = "aarch64")]
+pub mod aarch64;
+
+/// Base indices for the first 64 output bytes (lanes 0-7).
+/// Each entry indicates the starting input byte index for that output byte group.
+/// Pattern: `[0*2, 4*2, 2*2, 6*2, 1*2, 5*2, 3*2, 7*2]` = `[0, 8, 4, 12, 2, 10, 6, 14]`
+pub(crate) const BASE_PATTERN_FIRST: [usize; 8] = [0, 8, 4, 12, 2, 10, 6, 14];
+
+/// Base indices for the second 64 output bytes (lanes 8-15).
+/// Pattern: first pattern + 1 = `[1, 9, 5, 13, 3, 11, 7, 15]`
+pub(crate) const BASE_PATTERN_SECOND: [usize; 8] = [1, 9, 5, 13, 3, 11, 7, 15];
+
+/// Masks for transposing 8x8 bit blocks.
+pub(crate) const TRANSPOSE_2X2: u64 = 0x00AA_00AA_00AA_00AA;
+pub(crate) const TRANSPOSE_4X4: u64 = 0x0000_CCCC_0000_CCCC;
+pub(crate) const TRANSPOSE_8X8: u64 = 0x0000_0000_F0F0_F0F0;
+
+/// Reinterpret a 1024-bit block (`[u64; 16]`) as its 128 little-endian bytes.
+#[inline]
+#[must_use]
+pub(crate) fn as_byte_array(block: &[u64; 16]) -> &[u8; 128] {
+    // SAFETY: `[u64; 16]` and `[u8; 128]` have identical size (128 bytes). Every bit
+    // pattern is a valid `u8`, and the source is over-aligned for a `u8` array.
+    unsafe { &*block.as_ptr().cast::<[u8; 128]>() }
+}
+
+/// Reinterpret a mutable 1024-bit block (`[u64; 16]`) as its 128 little-endian bytes.
+#[inline]
+#[must_use]
+pub(crate) fn as_byte_array_mut(block: &mut [u64; 16]) -> &mut [u8; 128] {
+    // SAFETY: `[u64; 16]` and `[u8; 128]` have identical size (128 bytes). Every bit
+    // pattern is a valid `u8`, and the source is over-aligned for a `u8` array.
+    unsafe { &mut *block.as_mut_ptr().cast::<[u8; 128]>() }
+}
+
+/// Whether the AVX-512 VBMI implementation should be used.
+///
+/// Resolved at runtime with the `std` feature, otherwise at compile time.
+#[cfg(target_arch = "x86_64")]
+#[inline]
+fn detect_vbmi() -> bool {
+    #[cfg(feature = "std")]
+    {
+        std::is_x86_feature_detected!("avx512vbmi")
+            && std::is_x86_feature_detected!("avx512bw")
+            && std::is_x86_feature_detected!("avx512f")
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        cfg!(all(
+            target_feature = "avx512vbmi",
+            target_feature = "avx512bw",
+            target_feature = "avx512f"
+        ))
+    }
+}
+
+/// Whether the BMI2 implementation should be used.
+///
+/// Resolved at runtime with the `std` feature, otherwise at compile time.
+#[cfg(target_arch = "x86_64")]
+#[inline]
+fn detect_bmi2() -> bool {
+    #[cfg(feature = "std")]
+    {
+        std::is_x86_feature_detected!("bmi2")
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        cfg!(target_feature = "bmi2")
+    }
+}
+
+/// Transpose 1024 bits into `FastLanes` layout, dispatching to the best implementation.
+#[inline]
+pub fn transpose_bits(input: &[u64; 16], output: &mut [u64; 16]) {
+    #[cfg(target_arch = "x86_64")]
+    {
+        if detect_vbmi() {
+            // SAFETY: guarded by `detect_vbmi`.
+            unsafe { x86::transpose_bits_vbmi(input, output) }
+        } else if detect_bmi2() {
+            // SAFETY: guarded by `detect_bmi2`.
+            unsafe { x86::transpose_bits_bmi2(input, output) }
+        } else {
+            scalar::transpose_bits(input, output);
+        }
+    }
+    #[cfg(target_arch = "aarch64")]
+    // SAFETY: NEON is always available on aarch64.
+    unsafe {
+        aarch64::transpose_bits_neon(input, output)
+    }
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    scalar::transpose_bits(input, output);
+}
+
+/// Untranspose 1024 bits from `FastLanes` layout, dispatching to the best implementation.
+#[inline]
+pub fn untranspose_bits(input: &[u64; 16], output: &mut [u64; 16]) {
+    #[cfg(target_arch = "x86_64")]
+    {
+        if detect_vbmi() {
+            // SAFETY: guarded by `detect_vbmi`.
+            unsafe { x86::untranspose_bits_vbmi(input, output) }
+        } else if detect_bmi2() {
+            // SAFETY: guarded by `detect_bmi2`.
+            unsafe { x86::untranspose_bits_bmi2(input, output) }
+        } else {
+            scalar::untranspose_bits(input, output);
+        }
+    }
+    #[cfg(target_arch = "aarch64")]
+    // SAFETY: NEON is always available on aarch64.
+    unsafe {
+        aarch64::untranspose_bits_neon(input, output)
+    }
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    scalar::untranspose_bits(input, output);
+}
+
+#[cfg(test)]
+pub(crate) fn generate_test_data(seed: u8) -> [u64; 16] {
+    let mut data = [0u64; 16];
+    for (i, byte) in as_byte_array_mut(&mut data).iter_mut().enumerate() {
+        *byte = seed.wrapping_mul(17).wrapping_add(i as u8).wrapping_mul(31);
+    }
+    data
+}
+
+/// Reference transpose built directly on top of [`crate::transpose`], one bit at a time.
+#[cfg(test)]
+pub(crate) fn transpose_bits_baseline(input: &[u64; 16], output: &mut [u64; 16]) {
+    let input = as_byte_array(input);
+    let output = as_byte_array_mut(output);
+    *output = [0u8; 128];
+    for in_bit in 0..1024 {
+        let out_bit = crate::transpose(in_bit);
+        let bit_val = (input[in_bit / 8] >> (in_bit % 8)) & 1;
+        output[out_bit / 8] |= bit_val << (out_bit % 8);
+    }
+}
+
+/// Reference untranspose: the inverse permutation of [`transpose_bits_baseline`].
+#[cfg(test)]
+pub(crate) fn untranspose_bits_baseline(input: &[u64; 16], output: &mut [u64; 16]) {
+    let input = as_byte_array(input);
+    let output = as_byte_array_mut(output);
+    *output = [0u8; 128];
+    for out_bit in 0..1024 {
+        let in_bit = crate::transpose(out_bit);
+        let bit_val = (input[in_bit / 8] >> (in_bit % 8)) & 1;
+        output[out_bit / 8] |= bit_val << (out_bit % 8);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_baseline_roundtrip() {
+        let input = generate_test_data(42);
+        let mut transposed = [0u64; 16];
+        let mut roundtrip = [0u64; 16];
+
+        transpose_bits_baseline(&input, &mut transposed);
+        untranspose_bits_baseline(&transposed, &mut roundtrip);
+
+        assert_eq!(input, roundtrip);
+    }
+
+    #[test]
+    fn test_dispatch_matches_baseline() {
+        for seed in [0, 42, 123, 255] {
+            let input = generate_test_data(seed);
+            let mut baseline_out = [0u64; 16];
+            let mut out = [0u64; 16];
+
+            transpose_bits_baseline(&input, &mut baseline_out);
+            transpose_bits(&input, &mut out);
+
+            assert_eq!(
+                baseline_out, out,
+                "transpose dispatch doesn't match baseline for seed {seed}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_untranspose_dispatch_matches_baseline() {
+        for seed in [0, 42, 123, 255] {
+            let input = generate_test_data(seed);
+            let mut baseline_out = [0u64; 16];
+            let mut out = [0u64; 16];
+
+            untranspose_bits_baseline(&input, &mut baseline_out);
+            untranspose_bits(&input, &mut out);
+
+            assert_eq!(
+                baseline_out, out,
+                "untranspose dispatch doesn't match baseline for seed {seed}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_dispatch_roundtrip() {
+        for seed in [0, 42, 123, 255] {
+            let input = generate_test_data(seed);
+            let mut transposed = [0u64; 16];
+            let mut roundtrip = [0u64; 16];
+
+            transpose_bits(&input, &mut transposed);
+            untranspose_bits(&transposed, &mut roundtrip);
+
+            assert_eq!(
+                input, roundtrip,
+                "dispatch roundtrip failed for seed {seed}"
+            );
+        }
+    }
+}

--- a/src/bit_transpose/scalar.rs
+++ b/src/bit_transpose/scalar.rs
@@ -1,0 +1,144 @@
+//! Portable scalar transpose using a 64-bit gather and the classic 8x8 bit-matrix
+//! transpose. Used as the fallback when no SIMD implementation is available.
+//!
+//! Conceptually this mirrors the SIMD kernels: each of the 16 byte-groups is gathered
+//! into a `u64`, run through an 8x8 bit transpose, and scattered back out. The SIMD
+//! kernels do eight groups at once in a single register; the scalar code does them one
+//! at a time and relies on the compiler to unroll the fixed-length loops.
+
+use crate::bit_transpose::as_byte_array;
+use crate::bit_transpose::as_byte_array_mut;
+use crate::bit_transpose::BASE_PATTERN_FIRST;
+use crate::bit_transpose::BASE_PATTERN_SECOND;
+use crate::bit_transpose::TRANSPOSE_2X2;
+use crate::bit_transpose::TRANSPOSE_4X4;
+use crate::bit_transpose::TRANSPOSE_8X8;
+
+/// The two halves of the `FastLanes` byte-group ordering.
+const HALVES: [[usize; 8]; 2] = [BASE_PATTERN_FIRST, BASE_PATTERN_SECOND];
+
+/// Transpose 8x8 bit blocks within a `u64` (each byte is a row).
+#[inline]
+fn transpose_8x8(mut x: u64) -> u64 {
+    // Step 1: Transpose 2x2 bit blocks
+    let t = (x ^ (x >> 7)) & TRANSPOSE_2X2;
+    x = x ^ t ^ (t << 7);
+    // Step 2: Transpose 4x4 bit blocks
+    let t = (x ^ (x >> 14)) & TRANSPOSE_4X4;
+    x = x ^ t ^ (t << 14);
+    // Step 3: Transpose 8x8 bit blocks
+    let t = (x ^ (x >> 28)) & TRANSPOSE_8X8;
+    x ^ t ^ (t << 28)
+}
+
+/// Gather 8 bytes at stride 16 into a `u64`.
+#[inline]
+fn gather(input: &[u8; 128], base: usize) -> u64 {
+    let mut result = 0u64;
+    for row in 0..8 {
+        result |= u64::from(input[base + row * 16]) << (row * 8);
+    }
+    result
+}
+
+/// Scatter a `u64` to 8 output bytes at stride 16.
+#[inline]
+fn scatter(output: &mut [u8; 128], base: usize, val: u64) {
+    for row in 0..8 {
+        output[base + row * 16] = (val >> (row * 8)) as u8;
+    }
+}
+
+/// Transpose one 1024-bit block using the scalar implementation.
+#[inline]
+pub fn transpose_bits(input: &[u64; 16], output: &mut [u64; 16]) {
+    let input = as_byte_array(input);
+    let output = as_byte_array_mut(output);
+    for (half, groups) in HALVES.iter().enumerate() {
+        for (group, &base) in groups.iter().enumerate() {
+            let row = transpose_8x8(gather(input, base));
+            for bit in 0..8 {
+                output[half * 64 + bit * 8 + group] = (row >> (bit * 8)) as u8;
+            }
+        }
+    }
+}
+
+/// Untranspose one 1024-bit block using the scalar implementation.
+#[inline]
+pub fn untranspose_bits(input: &[u64; 16], output: &mut [u64; 16]) {
+    let input = as_byte_array(input);
+    let output = as_byte_array_mut(output);
+    for (half, groups) in HALVES.iter().enumerate() {
+        for (group, &base) in groups.iter().enumerate() {
+            // Gather the 8 consecutive bytes of this group from the transposed layout.
+            let mut packed = 0u64;
+            for bit in 0..8 {
+                packed |= u64::from(input[half * 64 + bit * 8 + group]) << (bit * 8);
+            }
+            scatter(output, base, transpose_8x8(packed));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bit_transpose::generate_test_data;
+    use crate::bit_transpose::transpose_bits_baseline;
+
+    #[test]
+    fn test_scalar_matches_baseline() {
+        for seed in [0, 42, 123, 255] {
+            let input = generate_test_data(seed);
+            let mut baseline_out = [0u64; 16];
+            let mut scalar_out = [0u64; 16];
+
+            transpose_bits_baseline(&input, &mut baseline_out);
+            transpose_bits(&input, &mut scalar_out);
+
+            assert_eq!(
+                baseline_out, scalar_out,
+                "scalar transpose doesn't match baseline for seed {seed}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_scalar_roundtrip() {
+        for seed in [0, 42, 123, 255] {
+            let input = generate_test_data(seed);
+            let mut transposed = [0u64; 16];
+            let mut roundtrip = [0u64; 16];
+
+            transpose_bits(&input, &mut transposed);
+            untranspose_bits(&transposed, &mut roundtrip);
+
+            assert_eq!(input, roundtrip, "scalar roundtrip failed for seed {seed}");
+        }
+    }
+
+    #[test]
+    fn test_all_zeros() {
+        let input = [0u64; 16];
+        let mut output = [u64::MAX; 16];
+
+        transpose_bits(&input, &mut output);
+        assert_eq!(output, [0u64; 16]);
+
+        untranspose_bits(&input, &mut output);
+        assert_eq!(output, [0u64; 16]);
+    }
+
+    #[test]
+    fn test_all_ones() {
+        let input = [u64::MAX; 16];
+        let mut output = [0u64; 16];
+
+        transpose_bits(&input, &mut output);
+        assert_eq!(output, [u64::MAX; 16]);
+
+        untranspose_bits(&input, &mut output);
+        assert_eq!(output, [u64::MAX; 16]);
+    }
+}

--- a/src/bit_transpose/x86.rs
+++ b/src/bit_transpose/x86.rs
@@ -1,0 +1,326 @@
+//! x86-64 transpose implementations: BMI2 (`PEXT`/`PDEP`) and AVX-512 VBMI.
+#![cfg(target_arch = "x86_64")]
+
+use core::arch::x86_64::__m512i;
+use core::arch::x86_64::_mm512_and_si512;
+use core::arch::x86_64::_mm512_loadu_si512;
+use core::arch::x86_64::_mm512_permutex2var_epi8;
+use core::arch::x86_64::_mm512_permutexvar_epi8;
+use core::arch::x86_64::_mm512_set1_epi64;
+use core::arch::x86_64::_mm512_slli_epi64;
+use core::arch::x86_64::_mm512_srli_epi64;
+use core::arch::x86_64::_mm512_storeu_si512;
+use core::arch::x86_64::_mm512_xor_si512;
+use core::arch::x86_64::_pdep_u64;
+use core::arch::x86_64::_pext_u64;
+
+use crate::bit_transpose::as_byte_array;
+use crate::bit_transpose::as_byte_array_mut;
+use crate::bit_transpose::BASE_PATTERN_FIRST;
+use crate::bit_transpose::BASE_PATTERN_SECOND;
+use crate::bit_transpose::TRANSPOSE_2X2;
+use crate::bit_transpose::TRANSPOSE_4X4;
+use crate::bit_transpose::TRANSPOSE_8X8;
+
+/// Check if BMI2 is available (requires the `std` feature for runtime detection).
+#[cfg(feature = "std")]
+#[inline]
+#[must_use]
+pub fn has_bmi2() -> bool {
+    std::is_x86_feature_detected!("bmi2")
+}
+
+/// Check if AVX-512 VBMI (+ F + BW) is available (requires the `std` feature).
+#[cfg(feature = "std")]
+#[inline]
+#[must_use]
+pub fn has_vbmi() -> bool {
+    std::is_x86_feature_detected!("avx512vbmi")
+        && std::is_x86_feature_detected!("avx512bw")
+        && std::is_x86_feature_detected!("avx512f")
+}
+
+/// Per-bit-position masks selecting one bit out of every byte of a `u64`.
+const BIT_MASKS: [u64; 8] = [
+    0x0101_0101_0101_0101,
+    0x0202_0202_0202_0202,
+    0x0404_0404_0404_0404,
+    0x0808_0808_0808_0808,
+    0x1010_1010_1010_1010,
+    0x2020_2020_2020_2020,
+    0x4040_4040_4040_4040,
+    0x8080_8080_8080_8080,
+];
+
+/// Transpose 1024 bits using BMI2 `PEXT`.
+///
+/// `PEXT` extracts bits at positions specified by a mask into contiguous low bits.
+///
+/// # Safety
+/// Requires BMI2 support. Check with [`has_bmi2`] before calling.
+#[target_feature(enable = "bmi2")]
+#[inline]
+#[allow(unsafe_op_in_unsafe_fn)]
+pub unsafe fn transpose_bits_bmi2(input: &[u64; 16], output: &mut [u64; 16]) {
+    let input = as_byte_array(input);
+    let output = as_byte_array_mut(output);
+
+    for (half, groups) in [BASE_PATTERN_FIRST, BASE_PATTERN_SECOND].iter().enumerate() {
+        for (group, &base) in groups.iter().enumerate() {
+            let g = gather(input, base);
+            for (bit, &mask) in BIT_MASKS.iter().enumerate() {
+                output[half * 64 + bit * 8 + group] = _pext_u64(g, mask) as u8;
+            }
+        }
+    }
+}
+
+/// Untranspose 1024 bits using BMI2 `PDEP`.
+///
+/// For each output group of 8 bytes at stride 16, `PDEP` deposits the 8 input bytes
+/// into their respective bit positions, then the group is scattered out at once.
+///
+/// # Safety
+/// Requires BMI2 support. Check with [`has_bmi2`] before calling.
+#[target_feature(enable = "bmi2")]
+#[inline]
+#[allow(unsafe_op_in_unsafe_fn)]
+pub unsafe fn untranspose_bits_bmi2(input: &[u64; 16], output: &mut [u64; 16]) {
+    let input = as_byte_array(input);
+    let output = as_byte_array_mut(output);
+
+    for (half, groups) in [BASE_PATTERN_FIRST, BASE_PATTERN_SECOND].iter().enumerate() {
+        for (group, &base) in groups.iter().enumerate() {
+            let mut v = 0u64;
+            for (bit, &mask) in BIT_MASKS.iter().enumerate() {
+                v |= _pdep_u64(u64::from(input[half * 64 + bit * 8 + group]), mask);
+            }
+            for row in 0..8 {
+                output[base + row * 16] = (v >> (row * 8)) as u8;
+            }
+        }
+    }
+}
+
+/// Gather 8 bytes at stride 16 into a `u64`.
+#[inline]
+fn gather(input: &[u8; 128], base: usize) -> u64 {
+    let mut result = 0u64;
+    for row in 0..8 {
+        result |= u64::from(input[base + row * 16]) << (row * 8);
+    }
+    result
+}
+
+// Static permutation tables for VBMI gather operations.
+// Gather bytes at stride 16 for the 8 groups of each half (bases from BASE_PATTERN_*).
+static GATHER_FIRST: [u8; 64] = [
+    0, 16, 32, 48, 64, 80, 96, 112, // base 0
+    8, 24, 40, 56, 72, 88, 104, 120, // base 8
+    4, 20, 36, 52, 68, 84, 100, 116, // base 4
+    12, 28, 44, 60, 76, 92, 108, 124, // base 12
+    2, 18, 34, 50, 66, 82, 98, 114, // base 2
+    10, 26, 42, 58, 74, 90, 106, 122, // base 10
+    6, 22, 38, 54, 70, 86, 102, 118, // base 6
+    14, 30, 46, 62, 78, 94, 110, 126, // base 14
+];
+
+static GATHER_SECOND: [u8; 64] = [
+    1, 17, 33, 49, 65, 81, 97, 113, // base 1
+    9, 25, 41, 57, 73, 89, 105, 121, // base 9
+    5, 21, 37, 53, 69, 85, 101, 117, // base 5
+    13, 29, 45, 61, 77, 93, 109, 125, // base 13
+    3, 19, 35, 51, 67, 83, 99, 115, // base 3
+    11, 27, 43, 59, 75, 91, 107, 123, // base 11
+    7, 23, 39, 55, 71, 87, 103, 119, // base 7
+    15, 31, 47, 63, 79, 95, 111, 127, // base 15
+];
+
+// 8x8 byte transpose permutation for the scatter phase.
+// Input:  [g0b0..g0b7, g1b0..g1b7, ..., g7b0..g7b7] (8 groups of 8 bytes)
+// Output: [g0b0,g1b0,..,g7b0, g0b1,g1b1,..,g7b1, ...] (8 rows of 8 bytes)
+static SCATTER_8X8: [u8; 64] = [
+    0, 8, 16, 24, 32, 40, 48, 56, // byte 0 from each group
+    1, 9, 17, 25, 33, 41, 49, 57, // byte 1 from each group
+    2, 10, 18, 26, 34, 42, 50, 58, // byte 2 from each group
+    3, 11, 19, 27, 35, 43, 51, 59, // byte 3 from each group
+    4, 12, 20, 28, 36, 44, 52, 60, // byte 4 from each group
+    5, 13, 21, 29, 37, 45, 53, 61, // byte 5 from each group
+    6, 14, 22, 30, 38, 46, 54, 62, // byte 6 from each group
+    7, 15, 23, 31, 39, 47, 55, 63, // byte 7 from each group
+];
+
+/// Transpose 8x8 bit blocks of all 8 lanes of a ZMM register in parallel.
+#[target_feature(enable = "avx512f", enable = "avx512bw")]
+#[inline]
+#[allow(clippy::cast_possible_wrap, unsafe_op_in_unsafe_fn)]
+unsafe fn bit_transpose_8x8_zmm(mut v: __m512i) -> __m512i {
+    let mask1 = _mm512_set1_epi64(TRANSPOSE_2X2 as i64);
+    let mask2 = _mm512_set1_epi64(TRANSPOSE_4X4 as i64);
+    let mask3 = _mm512_set1_epi64(TRANSPOSE_8X8 as i64);
+
+    let t = _mm512_and_si512(_mm512_xor_si512(v, _mm512_srli_epi64::<7>(v)), mask1);
+    v = _mm512_xor_si512(_mm512_xor_si512(v, t), _mm512_slli_epi64::<7>(t));
+    let t = _mm512_and_si512(_mm512_xor_si512(v, _mm512_srli_epi64::<14>(v)), mask2);
+    v = _mm512_xor_si512(_mm512_xor_si512(v, t), _mm512_slli_epi64::<14>(t));
+    let t = _mm512_and_si512(_mm512_xor_si512(v, _mm512_srli_epi64::<28>(v)), mask3);
+    _mm512_xor_si512(_mm512_xor_si512(v, t), _mm512_slli_epi64::<28>(t))
+}
+
+/// Transpose 1024 bits using AVX-512 VBMI for vectorized gather and scatter.
+///
+/// Uses `vpermi2b` to gather bytes from stride-16 positions in parallel,
+/// and `vpermb` for the final 8x8 byte transpose to output format.
+///
+/// # Safety
+/// Requires AVX-512F, AVX-512BW, and AVX-512VBMI support. Check with [`has_vbmi`].
+#[target_feature(enable = "avx512f", enable = "avx512bw", enable = "avx512vbmi")]
+#[inline]
+#[allow(clippy::cast_ptr_alignment, unsafe_op_in_unsafe_fn)]
+pub unsafe fn transpose_bits_vbmi(input: &[u64; 16], output: &mut [u64; 16]) {
+    let input = as_byte_array(input);
+    let output = as_byte_array_mut(output);
+
+    let in_lo = _mm512_loadu_si512(input.as_ptr().cast::<__m512i>());
+    let in_hi = _mm512_loadu_si512(input.as_ptr().add(64).cast::<__m512i>());
+
+    let idx_scatter = _mm512_loadu_si512(SCATTER_8X8.as_ptr().cast::<__m512i>());
+
+    for (half, gather_idx) in [&GATHER_FIRST, &GATHER_SECOND].iter().enumerate() {
+        let idx = _mm512_loadu_si512(gather_idx.as_ptr().cast::<__m512i>());
+        let gathered = _mm512_permutex2var_epi8(in_lo, idx, in_hi);
+        let transposed = bit_transpose_8x8_zmm(gathered);
+        let scattered = _mm512_permutexvar_epi8(idx_scatter, transposed);
+        _mm512_storeu_si512(
+            output.as_mut_ptr().add(half * 64).cast::<__m512i>(),
+            scattered,
+        );
+    }
+}
+
+/// Untranspose 1024 bits using AVX-512 VBMI for vectorized gather.
+///
+/// # Safety
+/// Requires AVX-512F, AVX-512BW, and AVX-512VBMI support. Check with [`has_vbmi`].
+#[target_feature(enable = "avx512f", enable = "avx512bw", enable = "avx512vbmi")]
+#[inline]
+#[allow(clippy::cast_ptr_alignment, unsafe_op_in_unsafe_fn)]
+pub unsafe fn untranspose_bits_vbmi(input: &[u64; 16], output: &mut [u64; 16]) {
+    let input = as_byte_array(input);
+    let output = as_byte_array_mut(output);
+
+    // In the transposed layout the 8 bytes of a group are consecutive; this gather
+    // collects them into the eight u64 lanes of a ZMM register.
+    let gather_indices: [u8; 64] = SCATTER_8X8;
+    let idx = _mm512_loadu_si512(gather_indices.as_ptr().cast::<__m512i>());
+
+    for (half, groups) in [BASE_PATTERN_FIRST, BASE_PATTERN_SECOND].iter().enumerate() {
+        let in_half = _mm512_loadu_si512(input.as_ptr().add(half * 64).cast::<__m512i>());
+        let gathered = _mm512_permutexvar_epi8(idx, in_half);
+        let transposed = bit_transpose_8x8_zmm(gathered);
+
+        let mut lanes = [0u64; 8];
+        _mm512_storeu_si512(lanes.as_mut_ptr().cast::<__m512i>(), transposed);
+        for (group, &base) in groups.iter().enumerate() {
+            for row in 0..8 {
+                output[base + row * 16] = (lanes[group] >> (row * 8)) as u8;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "std")]
+    use super::*;
+    #[cfg(feature = "std")]
+    use crate::bit_transpose::generate_test_data;
+    #[cfg(feature = "std")]
+    use crate::bit_transpose::transpose_bits_baseline;
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_bmi2_matches_baseline() {
+        if !has_bmi2() {
+            return;
+        }
+        for seed in [0, 42, 123, 255] {
+            let input = generate_test_data(seed);
+            let mut baseline_out = [0u64; 16];
+            let mut bmi2_out = [0u64; 16];
+
+            transpose_bits_baseline(&input, &mut baseline_out);
+            // SAFETY: guarded by `has_bmi2`.
+            unsafe { transpose_bits_bmi2(&input, &mut bmi2_out) };
+
+            assert_eq!(
+                baseline_out, bmi2_out,
+                "BMI2 transpose doesn't match baseline for seed {seed}"
+            );
+        }
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_bmi2_roundtrip() {
+        if !has_bmi2() {
+            return;
+        }
+        for seed in [0, 42, 123, 255] {
+            let input = generate_test_data(seed);
+            let mut transposed = [0u64; 16];
+            let mut roundtrip = [0u64; 16];
+
+            // SAFETY: guarded by `has_bmi2`.
+            unsafe {
+                transpose_bits_bmi2(&input, &mut transposed);
+                untranspose_bits_bmi2(&transposed, &mut roundtrip);
+            }
+
+            assert_eq!(input, roundtrip, "BMI2 roundtrip failed for seed {seed}");
+        }
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_vbmi_matches_baseline() {
+        if !has_vbmi() {
+            return;
+        }
+        for seed in [0, 42, 123, 255] {
+            let input = generate_test_data(seed);
+            let mut baseline_out = [0u64; 16];
+            let mut vbmi_out = [0u64; 16];
+
+            transpose_bits_baseline(&input, &mut baseline_out);
+            // SAFETY: guarded by `has_vbmi`.
+            unsafe { transpose_bits_vbmi(&input, &mut vbmi_out) };
+
+            assert_eq!(
+                baseline_out, vbmi_out,
+                "VBMI transpose doesn't match baseline for seed {seed}"
+            );
+        }
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_vbmi_roundtrip() {
+        if !has_vbmi() {
+            return;
+        }
+        for seed in [0, 42, 123, 255] {
+            let input = generate_test_data(seed);
+            let mut transposed = [0u64; 16];
+            let mut roundtrip = [0u64; 16];
+
+            // SAFETY: guarded by `has_vbmi`.
+            unsafe {
+                transpose_bits_vbmi(&input, &mut transposed);
+                untranspose_bits_vbmi(&transposed, &mut roundtrip);
+            }
+
+            assert_eq!(input, roundtrip, "VBMI roundtrip failed for seed {seed}");
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,13 @@
 
 extern crate alloc;
 extern crate core;
+#[cfg(feature = "std")]
+extern crate std;
 
 use core::mem::size_of;
 use num_traits::{PrimInt, Unsigned};
 
+mod bit_transpose;
 mod bitpacking;
 mod bitpacking_cmp;
 mod delta;
@@ -14,6 +17,7 @@ mod macros;
 mod rle;
 mod transpose;
 
+pub use bit_transpose::*;
 pub use bitpacking::*;
 pub use bitpacking_cmp::*;
 pub use delta::*;


### PR DESCRIPTION
## Summary

This PR adds optimized implementations of the FastLanes 1024-bit bit-matrix transpose operation with architecture-specific SIMD kernels for x86-64 and AArch64, along with a portable scalar fallback.