### PR TITLE
Add width-generic x86 BMI2/VBMI untranspose for u8/u16/u32

### DIFF
--- a/benches/bit_transpose.rs
+++ b/benches/bit_transpose.rs
@@ -63,6 +63,7 @@ fn dispatch_untranspose<T: FastLanes>(bencher: Bencher) {
 mod x86 {
     use super::{bench_blocks, Bencher};
     use fastlanes::x86;
+    use fastlanes::FastLanes;
 
     #[divan::bench]
     fn bmi2_transpose(bencher: Bencher) {
@@ -73,13 +74,15 @@ mod x86 {
         bench_blocks(bencher, |i, o| unsafe { x86::transpose_bits_bmi2(i, o) });
     }
 
-    #[divan::bench]
-    fn bmi2_untranspose(bencher: Bencher) {
+    #[divan::bench(types = [u8, u16, u32, u64])]
+    fn bmi2_untranspose<T: FastLanes>(bencher: Bencher) {
         if !x86::has_bmi2() {
             return;
         }
         // SAFETY: guarded by `has_bmi2`.
-        bench_blocks(bencher, |i, o| unsafe { x86::untranspose_bits_bmi2(i, o) });
+        bench_blocks(bencher, |i, o| unsafe {
+            x86::untranspose_bits_bmi2::<T>(i, o);
+        });
     }
 
     #[divan::bench]
@@ -91,13 +94,15 @@ mod x86 {
         bench_blocks(bencher, |i, o| unsafe { x86::transpose_bits_vbmi(i, o) });
     }
 
-    #[divan::bench]
-    fn vbmi_untranspose(bencher: Bencher) {
+    #[divan::bench(types = [u8, u16, u32, u64])]
+    fn vbmi_untranspose<T: FastLanes>(bencher: Bencher) {
         if !x86::has_vbmi() {
             return;
         }
         // SAFETY: guarded by `has_vbmi`.
-        bench_blocks(bencher, |i, o| unsafe { x86::untranspose_bits_vbmi(i, o) });
+        bench_blocks(bencher, |i, o| unsafe {
+            x86::untranspose_bits_vbmi::<T>(i, o);
+        });
     }
 }
 
@@ -111,7 +116,7 @@ mod aarch64 {
     fn neon_transpose(bencher: Bencher) {
         // SAFETY: NEON is always available on aarch64.
         bench_blocks(bencher, |i, o| unsafe {
-            aarch64::transpose_bits_neon(i, o)
+            aarch64::transpose_bits_neon(i, o);
         });
     }
 
@@ -119,7 +124,7 @@ mod aarch64 {
     fn neon_untranspose<T: FastLanes>(bencher: Bencher) {
         // SAFETY: NEON is always available on aarch64.
         bench_blocks(bencher, |i, o| unsafe {
-            aarch64::untranspose_bits_neon::<T>(i, o)
+            aarch64::untranspose_bits_neon::<T>(i, o);
         });
     }
 }

--- a/src/bit_transpose/aarch64.rs
+++ b/src/bit_transpose/aarch64.rs
@@ -18,11 +18,11 @@ use core::arch::aarch64::vsubq_u8;
 
 use crate::bit_transpose::as_byte_array;
 use crate::bit_transpose::as_byte_array_mut;
+use crate::bit_transpose::group_tables;
 use crate::bit_transpose::TRANSPOSE_2X2;
 use crate::bit_transpose::TRANSPOSE_4X4;
 use crate::bit_transpose::TRANSPOSE_8X8;
 use crate::FastLanes;
-use crate::FL_ORDER;
 
 /// Gather indices for the first half from input[0..64] (low 4 bytes of each group).
 static GATHER_FIRST_LO: [[u8; 16]; 4] = [
@@ -172,58 +172,6 @@ pub unsafe fn transpose_bits_neon(input: &[u64; 16], output: &mut [u64; 16]) {
     }
 }
 
-/// Byte-gather indices that pull the 8 bytes of every group into contiguous group-major order
-/// for an element width of `tb` bits. Group `g = lhi * (tb/8) + hi` collects byte `llo` of its
-/// lane words from input byte `lhi*tb + hi + llo*(tb/8)`. See [`crate::scalar::untranspose_bits`].
-const fn gather_indices(tb: usize) -> [u8; 128] {
-    let bytes = tb / 8;
-    let mut idx = [0u8; 128];
-    let mut g = 0;
-    while g < 16 {
-        let lhi = g / bytes;
-        let hi = g % bytes;
-        let gather_base = lhi * tb + hi;
-        let mut llo = 0;
-        while llo < 8 {
-            idx[g * 8 + llo] = (gather_base + llo * bytes) as u8;
-            llo += 1;
-        }
-        g += 1;
-    }
-    idx
-}
-
-/// Byte-scatter indices applied after the per-group 8x8 transpose: transposed byte `g*8 + lo`
-/// lands at logical byte `FL_ORDER[hi]*2 + lhi + lo*16`. Expressed as a gather table for
-/// [`permute_128`]: `idx[logical_byte] = g*8 + lo`.
-const fn scatter_indices(tb: usize) -> [u8; 128] {
-    let bytes = tb / 8;
-    let mut idx = [0u8; 128];
-    let mut g = 0;
-    while g < 16 {
-        let lhi = g / bytes;
-        let hi = g % bytes;
-        let scatter_base = FL_ORDER[hi] * 2 + lhi;
-        let mut lo = 0;
-        while lo < 8 {
-            idx[scatter_base + lo * 16] = (g * 8 + lo) as u8;
-            lo += 1;
-        }
-        g += 1;
-    }
-    idx
-}
-
-static GATHER_8: [u8; 128] = gather_indices(8);
-static GATHER_16: [u8; 128] = gather_indices(16);
-static GATHER_32: [u8; 128] = gather_indices(32);
-static GATHER_64: [u8; 128] = gather_indices(64);
-
-static SCATTER_8: [u8; 128] = scatter_indices(8);
-static SCATTER_16: [u8; 128] = scatter_indices(16);
-static SCATTER_32: [u8; 128] = scatter_indices(32);
-static SCATTER_64: [u8; 128] = scatter_indices(64);
-
 /// Apply an arbitrary 128-byte gather permutation (`out[k] = src[idx[k]]`) using NEON TBL.
 ///
 /// `vqtbl4q_u8` only addresses 64 source bytes, returning 0 for indices `>= 64`. We split `src`
@@ -258,12 +206,7 @@ unsafe fn permute_128(src: &[u8; 128], idx: &[u8; 128]) -> [u8; 128] {
 #[inline]
 #[allow(unsafe_op_in_unsafe_fn)]
 pub unsafe fn untranspose_bits_neon<T: FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
-    let (gather_idx, scatter_idx): (&[u8; 128], &[u8; 128]) = match T::T {
-        8 => (&GATHER_8, &SCATTER_8),
-        16 => (&GATHER_16, &SCATTER_16),
-        32 => (&GATHER_32, &SCATTER_32),
-        _ => (&GATHER_64, &SCATTER_64),
-    };
+    let (gather_idx, scatter_idx) = group_tables::<T>();
 
     // Gather the 16 groups into contiguous group-major order.
     let gathered = permute_128(as_byte_array(input), gather_idx);

--- a/src/bit_transpose/aarch64.rs
+++ b/src/bit_transpose/aarch64.rs
@@ -18,7 +18,7 @@ use core::arch::aarch64::vsubq_u8;
 
 use crate::bit_transpose::as_byte_array;
 use crate::bit_transpose::as_byte_array_mut;
-use crate::bit_transpose::group_tables;
+use crate::bit_transpose::group_perm::group_tables;
 use crate::bit_transpose::TRANSPOSE_2X2;
 use crate::bit_transpose::TRANSPOSE_4X4;
 use crate::bit_transpose::TRANSPOSE_8X8;

--- a/src/bit_transpose/mod.rs
+++ b/src/bit_transpose/mod.rs
@@ -300,19 +300,26 @@ mod tests {
 
     #[test]
     fn test_untranspose_dispatch_matches_baseline() {
-        for seed in [0, 42, 123, 255] {
-            let input = generate_test_data(seed);
-            let mut baseline_out = [0u64; 16];
-            let mut out = [0u64; 16];
+        fn check<T: crate::FastLanes>() {
+            for seed in [0, 42, 123, 255] {
+                let input = generate_test_data(seed);
+                let mut baseline_out = [0u64; 16];
+                let mut out = [0u64; 16];
 
-            untranspose_bits_baseline::<u64>(&input, &mut baseline_out);
-            untranspose_bits::<u64>(&input, &mut out);
+                untranspose_bits_baseline::<T>(&input, &mut baseline_out);
+                untranspose_bits::<T>(&input, &mut out);
 
-            assert_eq!(
-                baseline_out, out,
-                "untranspose dispatch doesn't match baseline for seed {seed}"
-            );
+                assert_eq!(
+                    baseline_out, out,
+                    "untranspose dispatch doesn't match baseline for type={} seed={seed}",
+                    core::any::type_name::<T>()
+                );
+            }
         }
+        check::<u8>();
+        check::<u16>();
+        check::<u32>();
+        check::<u64>();
     }
 
     #[test]
@@ -329,6 +336,116 @@ mod tests {
                 input, roundtrip,
                 "dispatch roundtrip failed for seed {seed}"
             );
+        }
+    }
+
+    /// The shared `group_perm` gather/scatter tables are consumed only by the SIMD kernels
+    /// (NEON on `aarch64`, VBMI on `x86_64`) — so on a given host most of them are never executed
+    /// (e.g. on an x86 CI runner without AVX-512VBMI nothing touches them, since BMI2 computes
+    /// its indices inline). These two tests exercise the tables directly, on every architecture,
+    /// independent of any SIMD support.
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    mod group_perm_tables {
+        use super::*;
+
+        /// Portable scalar re-implementation of the SIMD width-generic untranspose, driven purely
+        /// by the shared tables: gather the 16 byte-groups into group-major order, 8x8-transpose
+        /// each group, then scatter back. Equivalent to the NEON/VBMI kernels but in plain Rust,
+        /// so it validates the table *data* against the bit-level baseline on any host.
+        fn untranspose_via_tables<T: crate::FastLanes>(input: &[u64; 16]) -> [u64; 16] {
+            fn transpose_8x8(mut x: u64) -> u64 {
+                let t = (x ^ (x >> 7)) & TRANSPOSE_2X2;
+                x = x ^ t ^ (t << 7);
+                let t = (x ^ (x >> 14)) & TRANSPOSE_4X4;
+                x = x ^ t ^ (t << 14);
+                let t = (x ^ (x >> 28)) & TRANSPOSE_8X8;
+                x ^ t ^ (t << 28)
+            }
+
+            let (gather, scatter) = group_perm::group_tables::<T>();
+            let src = as_byte_array(input);
+
+            // Gather: group-major order, `grouped[k] = src[gather[k]]`.
+            let mut grouped = [0u8; 128];
+            for k in 0..128 {
+                grouped[k] = src[gather[k] as usize];
+            }
+
+            // 8x8 bit-transpose each of the 16 groups (8 bytes each).
+            let mut transposed = [0u8; 128];
+            for g in 0..16 {
+                let mut word = 0u64;
+                for b in 0..8 {
+                    word |= u64::from(grouped[g * 8 + b]) << (b * 8);
+                }
+                let w = transpose_8x8(word);
+                for b in 0..8 {
+                    transposed[g * 8 + b] = (w >> (b * 8)) as u8;
+                }
+            }
+
+            // Scatter: `out[k] = transposed[scatter[k]]`.
+            let mut out = [0u64; 16];
+            let dst = as_byte_array_mut(&mut out);
+            for k in 0..128 {
+                dst[k] = transposed[scatter[k] as usize];
+            }
+            out
+        }
+
+        #[test]
+        fn tables_match_baseline_all_widths() {
+            fn check<T: crate::FastLanes>() {
+                for seed in [0, 1, 42, 123, 200, 255] {
+                    let input = generate_test_data(seed);
+                    let mut baseline = [0u64; 16];
+                    untranspose_bits_baseline::<T>(&input, &mut baseline);
+                    assert_eq!(
+                        untranspose_via_tables::<T>(&input),
+                        baseline,
+                        "group_perm tables != baseline for type={} seed={seed}",
+                        core::any::type_name::<T>()
+                    );
+                }
+            }
+            check::<u8>();
+            check::<u16>();
+            check::<u32>();
+            check::<u64>();
+        }
+
+        /// Both tables must be permutations of `0..128` — every input byte is read exactly once
+        /// (gather) and every output byte is written exactly once (scatter). A duplicated or
+        /// dropped index would silently corrupt data, so assert bijectivity for every width.
+        #[test]
+        fn tables_are_permutations() {
+            fn is_permutation(t: &[u8; 128]) -> bool {
+                let mut seen = [false; 128];
+                for &i in t {
+                    if i as usize >= 128 || seen[i as usize] {
+                        return false;
+                    }
+                    seen[i as usize] = true;
+                }
+                seen.iter().all(|&b| b)
+            }
+            fn check<T: crate::FastLanes>() {
+                let (gather, scatter) = group_perm::group_tables::<T>();
+                assert!(
+                    is_permutation(gather),
+                    "gather table for {} is not a permutation",
+                    core::any::type_name::<T>()
+                );
+                assert!(
+                    is_permutation(scatter),
+                    "scatter table for {} is not a permutation",
+                    core::any::type_name::<T>()
+                );
+            }
+            check::<u8>();
+            check::<u16>();
+            check::<u32>();
+            check::<u64>();
         }
     }
 }

--- a/src/bit_transpose/mod.rs
+++ b/src/bit_transpose/mod.rs
@@ -46,79 +46,72 @@ pub(crate) const TRANSPOSE_2X2: u64 = 0x00AA_00AA_00AA_00AA;
 pub(crate) const TRANSPOSE_4X4: u64 = 0x0000_CCCC_0000_CCCC;
 pub(crate) const TRANSPOSE_8X8: u64 = 0x0000_0000_F0F0_F0F0;
 
-/// Byte-gather indices that pull the 8 bytes of every group into contiguous group-major order
-/// for an element width of `tb` bits. Group `g = lhi * (tb/8) + hi` collects byte `llo` of its
-/// lane words from input byte `lhi*tb + hi + llo*(tb/8)`. See [`crate::bit_transpose::scalar::untranspose_bits`].
+/// Group-major gather/scatter permutation tables shared by the SIMD width-generic untranspose
+/// kernels (NEON and AVX-512 VBMI). Only built for the architectures that have such a kernel.
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-pub(crate) const fn gather_indices(tb: usize) -> [u8; 128] {
-    let bytes = tb / 8;
-    let mut idx = [0u8; 128];
-    let mut g = 0;
-    while g < 16 {
-        let lhi = g / bytes;
-        let hi = g % bytes;
-        let gather_base = lhi * tb + hi;
-        let mut llo = 0;
-        while llo < 8 {
-            idx[g * 8 + llo] = (gather_base + llo * bytes) as u8;
-            llo += 1;
+pub(crate) mod group_perm {
+    /// Byte-gather indices that pull the 8 bytes of every group into contiguous group-major order
+    /// for an element width of `tb` bits. Group `g = lhi * (tb/8) + hi` collects byte `llo` of its
+    /// lane words from input byte `lhi*tb + hi + llo*(tb/8)`. See
+    /// [`crate::bit_transpose::scalar::untranspose_bits`].
+    const fn gather_indices(tb: usize) -> [u8; 128] {
+        let bytes = tb / 8;
+        let mut idx = [0u8; 128];
+        let mut g = 0;
+        while g < 16 {
+            let lhi = g / bytes;
+            let hi = g % bytes;
+            let gather_base = lhi * tb + hi;
+            let mut llo = 0;
+            while llo < 8 {
+                idx[g * 8 + llo] = (gather_base + llo * bytes) as u8;
+                llo += 1;
+            }
+            g += 1;
         }
-        g += 1;
+        idx
     }
-    idx
-}
 
-/// Byte-scatter indices applied after the per-group 8x8 transpose: transposed byte `g*8 + lo`
-/// lands at logical byte `FL_ORDER[hi]*2 + lhi + lo*16`. Expressed as a gather table:
-/// `idx[logical_byte] = g*8 + lo`.
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-pub(crate) const fn scatter_indices(tb: usize) -> [u8; 128] {
-    let bytes = tb / 8;
-    let mut idx = [0u8; 128];
-    let mut g = 0;
-    while g < 16 {
-        let lhi = g / bytes;
-        let hi = g % bytes;
-        let scatter_base = crate::FL_ORDER[hi] * 2 + lhi;
-        let mut lo = 0;
-        while lo < 8 {
-            idx[scatter_base + lo * 16] = (g * 8 + lo) as u8;
-            lo += 1;
+    /// Byte-scatter indices applied after the per-group 8x8 transpose: transposed byte `g*8 + lo`
+    /// lands at logical byte `FL_ORDER[hi]*2 + lhi + lo*16`. Expressed as a gather table:
+    /// `idx[logical_byte] = g*8 + lo`.
+    const fn scatter_indices(tb: usize) -> [u8; 128] {
+        let bytes = tb / 8;
+        let mut idx = [0u8; 128];
+        let mut g = 0;
+        while g < 16 {
+            let lhi = g / bytes;
+            let hi = g % bytes;
+            let scatter_base = crate::FL_ORDER[hi] * 2 + lhi;
+            let mut lo = 0;
+            while lo < 8 {
+                idx[scatter_base + lo * 16] = (g * 8 + lo) as u8;
+                lo += 1;
+            }
+            g += 1;
         }
-        g += 1;
+        idx
     }
-    idx
-}
 
-/// Group-major gather tables, indexed by element width (bits). Shared by the NEON and AVX-512
-/// VBMI width-generic untranspose kernels.
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-pub(crate) static GATHER_8: [u8; 128] = gather_indices(8);
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-pub(crate) static GATHER_16: [u8; 128] = gather_indices(16);
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-pub(crate) static GATHER_32: [u8; 128] = gather_indices(32);
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-pub(crate) static GATHER_64: [u8; 128] = gather_indices(64);
+    static GATHER_8: [u8; 128] = gather_indices(8);
+    static GATHER_16: [u8; 128] = gather_indices(16);
+    static GATHER_32: [u8; 128] = gather_indices(32);
+    static GATHER_64: [u8; 128] = gather_indices(64);
 
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-pub(crate) static SCATTER_8: [u8; 128] = scatter_indices(8);
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-pub(crate) static SCATTER_16: [u8; 128] = scatter_indices(16);
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-pub(crate) static SCATTER_32: [u8; 128] = scatter_indices(32);
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-pub(crate) static SCATTER_64: [u8; 128] = scatter_indices(64);
+    static SCATTER_8: [u8; 128] = scatter_indices(8);
+    static SCATTER_16: [u8; 128] = scatter_indices(16);
+    static SCATTER_32: [u8; 128] = scatter_indices(32);
+    static SCATTER_64: [u8; 128] = scatter_indices(64);
 
-/// Select the `(gather, scatter)` group-major permutation tables for an element width.
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-#[inline]
-pub(crate) fn group_tables<T: crate::FastLanes>() -> (&'static [u8; 128], &'static [u8; 128]) {
-    match T::T {
-        8 => (&GATHER_8, &SCATTER_8),
-        16 => (&GATHER_16, &SCATTER_16),
-        32 => (&GATHER_32, &SCATTER_32),
-        _ => (&GATHER_64, &SCATTER_64),
+    /// Select the `(gather, scatter)` group-major permutation tables for an element width.
+    #[inline]
+    pub(crate) fn group_tables<T: crate::FastLanes>() -> (&'static [u8; 128], &'static [u8; 128]) {
+        match T::T {
+            8 => (&GATHER_8, &SCATTER_8),
+            16 => (&GATHER_16, &SCATTER_16),
+            32 => (&GATHER_32, &SCATTER_32),
+            _ => (&GATHER_64, &SCATTER_64),
+        }
     }
 }
 

--- a/src/bit_transpose/mod.rs
+++ b/src/bit_transpose/mod.rs
@@ -46,6 +46,82 @@ pub(crate) const TRANSPOSE_2X2: u64 = 0x00AA_00AA_00AA_00AA;
 pub(crate) const TRANSPOSE_4X4: u64 = 0x0000_CCCC_0000_CCCC;
 pub(crate) const TRANSPOSE_8X8: u64 = 0x0000_0000_F0F0_F0F0;
 
+/// Byte-gather indices that pull the 8 bytes of every group into contiguous group-major order
+/// for an element width of `tb` bits. Group `g = lhi * (tb/8) + hi` collects byte `llo` of its
+/// lane words from input byte `lhi*tb + hi + llo*(tb/8)`. See [`crate::bit_transpose::scalar::untranspose_bits`].
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+pub(crate) const fn gather_indices(tb: usize) -> [u8; 128] {
+    let bytes = tb / 8;
+    let mut idx = [0u8; 128];
+    let mut g = 0;
+    while g < 16 {
+        let lhi = g / bytes;
+        let hi = g % bytes;
+        let gather_base = lhi * tb + hi;
+        let mut llo = 0;
+        while llo < 8 {
+            idx[g * 8 + llo] = (gather_base + llo * bytes) as u8;
+            llo += 1;
+        }
+        g += 1;
+    }
+    idx
+}
+
+/// Byte-scatter indices applied after the per-group 8x8 transpose: transposed byte `g*8 + lo`
+/// lands at logical byte `FL_ORDER[hi]*2 + lhi + lo*16`. Expressed as a gather table:
+/// `idx[logical_byte] = g*8 + lo`.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+pub(crate) const fn scatter_indices(tb: usize) -> [u8; 128] {
+    let bytes = tb / 8;
+    let mut idx = [0u8; 128];
+    let mut g = 0;
+    while g < 16 {
+        let lhi = g / bytes;
+        let hi = g % bytes;
+        let scatter_base = crate::FL_ORDER[hi] * 2 + lhi;
+        let mut lo = 0;
+        while lo < 8 {
+            idx[scatter_base + lo * 16] = (g * 8 + lo) as u8;
+            lo += 1;
+        }
+        g += 1;
+    }
+    idx
+}
+
+/// Group-major gather tables, indexed by element width (bits). Shared by the NEON and AVX-512
+/// VBMI width-generic untranspose kernels.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+pub(crate) static GATHER_8: [u8; 128] = gather_indices(8);
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+pub(crate) static GATHER_16: [u8; 128] = gather_indices(16);
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+pub(crate) static GATHER_32: [u8; 128] = gather_indices(32);
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+pub(crate) static GATHER_64: [u8; 128] = gather_indices(64);
+
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+pub(crate) static SCATTER_8: [u8; 128] = scatter_indices(8);
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+pub(crate) static SCATTER_16: [u8; 128] = scatter_indices(16);
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+pub(crate) static SCATTER_32: [u8; 128] = scatter_indices(32);
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+pub(crate) static SCATTER_64: [u8; 128] = scatter_indices(64);
+
+/// Select the `(gather, scatter)` group-major permutation tables for an element width.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[inline]
+pub(crate) fn group_tables<T: crate::FastLanes>() -> (&'static [u8; 128], &'static [u8; 128]) {
+    match T::T {
+        8 => (&GATHER_8, &SCATTER_8),
+        16 => (&GATHER_16, &SCATTER_16),
+        32 => (&GATHER_32, &SCATTER_32),
+        _ => (&GATHER_64, &SCATTER_64),
+    }
+}
+
 /// Reinterpret a 1024-bit block (`[u64; 16]`) as its 128 little-endian bytes.
 #[inline]
 #[must_use]
@@ -133,18 +209,12 @@ pub fn transpose_bits(input: &[u64; 16], output: &mut [u64; 16]) {
 pub fn untranspose_bits<T: crate::FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
     #[cfg(target_arch = "x86_64")]
     {
-        // The BMI2/VBMI kernels currently only implement the `u64` (16-lane) transpose; other
-        // widths fall back to scalar.
-        //
-        // TODO(x86): add width-generic `untranspose_bits_{bmi2,vbmi}::<T>` kernels (mirroring the
-        // NEON `permute_128` + per-group 8x8 transpose approach in `aarch64.rs`) and route u8/u16/
-        // u32 through them here instead of the scalar fallback.
-        if T::T == 64 && detect_vbmi() {
+        if detect_vbmi() {
             // SAFETY: guarded by `detect_vbmi`.
-            unsafe { x86::untranspose_bits_vbmi(input, output) }
-        } else if T::T == 64 && detect_bmi2() {
+            unsafe { x86::untranspose_bits_vbmi::<T>(input, output) }
+        } else if detect_bmi2() {
             // SAFETY: guarded by `detect_bmi2`.
-            unsafe { x86::untranspose_bits_bmi2(input, output) }
+            unsafe { x86::untranspose_bits_bmi2::<T>(input, output) }
         } else {
             scalar::untranspose_bits::<T>(input, output);
         }

--- a/src/bit_transpose/mod.rs
+++ b/src/bit_transpose/mod.rs
@@ -310,7 +310,8 @@ mod tests {
                 untranspose_bits::<T>(&input, &mut out);
 
                 assert_eq!(
-                    baseline_out, out,
+                    baseline_out,
+                    out,
                     "untranspose dispatch doesn't match baseline for type={} seed={seed}",
                     core::any::type_name::<T>()
                 );

--- a/src/bit_transpose/x86.rs
+++ b/src/bit_transpose/x86.rs
@@ -16,7 +16,7 @@ use core::arch::x86_64::_pext_u64;
 
 use crate::bit_transpose::as_byte_array;
 use crate::bit_transpose::as_byte_array_mut;
-use crate::bit_transpose::group_tables;
+use crate::bit_transpose::group_perm::group_tables;
 use crate::bit_transpose::BASE_PATTERN_FIRST;
 use crate::bit_transpose::BASE_PATTERN_SECOND;
 use crate::bit_transpose::TRANSPOSE_2X2;

--- a/src/bit_transpose/x86.rs
+++ b/src/bit_transpose/x86.rs
@@ -16,11 +16,14 @@ use core::arch::x86_64::_pext_u64;
 
 use crate::bit_transpose::as_byte_array;
 use crate::bit_transpose::as_byte_array_mut;
+use crate::bit_transpose::group_tables;
 use crate::bit_transpose::BASE_PATTERN_FIRST;
 use crate::bit_transpose::BASE_PATTERN_SECOND;
 use crate::bit_transpose::TRANSPOSE_2X2;
 use crate::bit_transpose::TRANSPOSE_4X4;
 use crate::bit_transpose::TRANSPOSE_8X8;
+use crate::FastLanes;
+use crate::FL_ORDER;
 
 /// Check if BMI2 is available (requires the `std` feature for runtime detection).
 #[cfg(feature = "std")]
@@ -75,28 +78,36 @@ pub unsafe fn transpose_bits_bmi2(input: &[u64; 16], output: &mut [u64; 16]) {
     }
 }
 
-/// Untranspose 1024 bits using BMI2 `PDEP`.
+/// Untranspose a `T`-width comparison mask (1024 bits) using BMI2 `PDEP`.
 ///
-/// For each output group of 8 bytes at stride 16, `PDEP` deposits the 8 input bytes
-/// into their respective bit positions, then the group is scattered out at once.
+/// Regardless of width the 128 bytes factor into 16 groups of 8 bytes, each an independent 8x8
+/// bit transpose (see [`crate::bit_transpose::scalar::untranspose_bits`]). The width only changes
+/// the gather stride and the scatter base. For each group we gather its 8 bytes (at stride
+/// `T::T / 8`) and use `PDEP` to deposit byte `llo` into bit-position `llo` of all 8 packed
+/// output bytes — which is exactly the 8x8 bit transpose — then scatter the group at stride 16.
+/// For `T = u64` this is the canonical `FastLanes` bit untranspose.
 ///
 /// # Safety
 /// Requires BMI2 support. Check with [`has_bmi2`] before calling.
 #[target_feature(enable = "bmi2")]
 #[inline]
 #[allow(unsafe_op_in_unsafe_fn)]
-pub unsafe fn untranspose_bits_bmi2(input: &[u64; 16], output: &mut [u64; 16]) {
+pub unsafe fn untranspose_bits_bmi2<T: FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
     let input = as_byte_array(input);
     let output = as_byte_array_mut(output);
 
-    for (half, groups) in [BASE_PATTERN_FIRST, BASE_PATTERN_SECOND].iter().enumerate() {
-        for (group, &base) in groups.iter().enumerate() {
+    let bytes = T::T / 8;
+    let lhi_count = 128 / T::T;
+    for lhi in 0..lhi_count {
+        for hi in 0..bytes {
+            let gather_base = lhi * T::T + hi;
             let mut v = 0u64;
-            for (bit, &mask) in BIT_MASKS.iter().enumerate() {
-                v |= _pdep_u64(u64::from(input[half * 64 + bit * 8 + group]), mask);
+            for (llo, &mask) in BIT_MASKS.iter().enumerate() {
+                v |= _pdep_u64(u64::from(input[gather_base + llo * bytes]), mask);
             }
+            let scatter_base = FL_ORDER[hi] * 2 + lhi;
             for row in 0..8 {
-                output[base + row * 16] = (v >> (row * 8)) as u8;
+                output[scatter_base + row * 16] = (v >> (row * 8)) as u8;
             }
         }
     }
@@ -198,14 +209,27 @@ pub unsafe fn transpose_bits_vbmi(input: &[u64; 16], output: &mut [u64; 16]) {
     }
 }
 
-/// Untranspose 1024 bits using AVX-512 VBMI for vectorized gather.
+/// Untranspose a `T`-width comparison mask (1024 bits) using AVX-512 VBMI.
+///
+/// Regardless of width the 128 bytes factor into 16 groups of 8 bytes, each an independent 8x8
+/// bit transpose. The `T = 64` block keeps the original kernel (gather within each 64-byte half
+/// with `vpermb`, then scatter); narrower widths use the width-generic [`untranspose_bits_vbmi_lt64`]
+/// kernel whose groups span both halves. For `T = u64` this is the canonical `FastLanes` bit
+/// untranspose.
 ///
 /// # Safety
 /// Requires AVX-512F, AVX-512BW, and AVX-512VBMI support. Check with [`has_vbmi`].
 #[target_feature(enable = "avx512f", enable = "avx512bw", enable = "avx512vbmi")]
 #[inline]
 #[allow(clippy::cast_ptr_alignment, unsafe_op_in_unsafe_fn)]
-pub unsafe fn untranspose_bits_vbmi(input: &[u64; 16], output: &mut [u64; 16]) {
+pub unsafe fn untranspose_bits_vbmi<T: FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
+    // `T::T` is a compile-time constant, so this branch is resolved at monomorphization and the
+    // unused arm is eliminated. The `u64` arm is kept byte-identical to the original kernel.
+    if T::T != 64 {
+        untranspose_bits_vbmi_lt64::<T>(input, output);
+        return;
+    }
+
     let input = as_byte_array(input);
     let output = as_byte_array_mut(output);
 
@@ -229,6 +253,51 @@ pub unsafe fn untranspose_bits_vbmi(input: &[u64; 16], output: &mut [u64; 16]) {
     }
 }
 
+/// Width-generic (`T::T < 64`) VBMI untranspose for the narrow comparison-mask widths.
+///
+/// Mirrors the width-generic NEON kernel: `vpermi2b` gathers the 16 eight-byte groups into
+/// group-major order across two ZMM registers (each 64-bit lane is one group), every lane is
+/// 8x8 bit-transposed in parallel, then a second pair of `vpermi2b` scatters the transposed
+/// groups to their logical byte positions. For these widths a group spans both 64-byte halves,
+/// so the two-source `vpermi2b` is required (unlike the single-source `vpermb` in the `u64` path).
+///
+/// # Safety
+/// Requires AVX-512F, AVX-512BW, and AVX-512VBMI support. Check with [`has_vbmi`].
+#[target_feature(enable = "avx512f", enable = "avx512bw", enable = "avx512vbmi")]
+#[inline]
+#[allow(clippy::cast_ptr_alignment, unsafe_op_in_unsafe_fn)]
+unsafe fn untranspose_bits_vbmi_lt64<T: FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
+    let input = as_byte_array(input);
+    let output = as_byte_array_mut(output);
+    let (gather_idx, scatter_idx) = group_tables::<T>();
+
+    let in_lo = _mm512_loadu_si512(input.as_ptr().cast::<__m512i>());
+    let in_hi = _mm512_loadu_si512(input.as_ptr().add(64).cast::<__m512i>());
+
+    // Gather the 16 groups (8 bytes each) into group-major order: groups 0..7 in `grp0`,
+    // groups 8..15 in `grp1`. Each 64-bit lane holds one group's 8 bytes.
+    let g_lo = _mm512_loadu_si512(gather_idx.as_ptr().cast::<__m512i>());
+    let g_hi = _mm512_loadu_si512(gather_idx.as_ptr().add(64).cast::<__m512i>());
+    let grp0 = _mm512_permutex2var_epi8(in_lo, g_lo, in_hi);
+    let grp1 = _mm512_permutex2var_epi8(in_lo, g_hi, in_hi);
+
+    // 8x8 bit-transpose every group (all 8 lanes of each register in parallel).
+    let t0 = bit_transpose_8x8_zmm(grp0);
+    let t1 = bit_transpose_8x8_zmm(grp1);
+
+    // Scatter the transposed groups to their logical byte positions.
+    let s_lo = _mm512_loadu_si512(scatter_idx.as_ptr().cast::<__m512i>());
+    let s_hi = _mm512_loadu_si512(scatter_idx.as_ptr().add(64).cast::<__m512i>());
+    _mm512_storeu_si512(
+        output.as_mut_ptr().cast::<__m512i>(),
+        _mm512_permutex2var_epi8(t0, s_lo, t1),
+    );
+    _mm512_storeu_si512(
+        output.as_mut_ptr().add(64).cast::<__m512i>(),
+        _mm512_permutex2var_epi8(t0, s_hi, t1),
+    );
+}
+
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "std")]
@@ -237,6 +306,8 @@ mod tests {
     use crate::bit_transpose::generate_test_data;
     #[cfg(feature = "std")]
     use crate::bit_transpose::transpose_bits_baseline;
+    #[cfg(feature = "std")]
+    use crate::bit_transpose::untranspose_bits_baseline;
 
     #[cfg(feature = "std")]
     #[test]
@@ -274,11 +345,43 @@ mod tests {
             // SAFETY: guarded by `has_bmi2`.
             unsafe {
                 transpose_bits_bmi2(&input, &mut transposed);
-                untranspose_bits_bmi2(&transposed, &mut roundtrip);
+                untranspose_bits_bmi2::<u64>(&transposed, &mut roundtrip);
             }
 
             assert_eq!(input, roundtrip, "BMI2 roundtrip failed for seed {seed}");
         }
+    }
+
+    /// The width-generic BMI2 untranspose must match the width-parameterized baseline for every
+    /// element width.
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_bmi2_untranspose_all_widths_match_baseline() {
+        fn check<T: FastLanes>() {
+            for seed in [0, 42, 123, 255] {
+                let input = generate_test_data(seed);
+                let mut baseline_out = [0u64; 16];
+                let mut bmi2_out = [0u64; 16];
+
+                untranspose_bits_baseline::<T>(&input, &mut baseline_out);
+                // SAFETY: guarded by `has_bmi2`.
+                unsafe { untranspose_bits_bmi2::<T>(&input, &mut bmi2_out) };
+
+                assert_eq!(
+                    baseline_out,
+                    bmi2_out,
+                    "BMI2 untranspose != baseline for type={} seed={seed}",
+                    core::any::type_name::<T>()
+                );
+            }
+        }
+        if !has_bmi2() {
+            return;
+        }
+        check::<u8>();
+        check::<u16>();
+        check::<u32>();
+        check::<u64>();
     }
 
     #[cfg(feature = "std")]
@@ -317,10 +420,42 @@ mod tests {
             // SAFETY: guarded by `has_vbmi`.
             unsafe {
                 transpose_bits_vbmi(&input, &mut transposed);
-                untranspose_bits_vbmi(&transposed, &mut roundtrip);
+                untranspose_bits_vbmi::<u64>(&transposed, &mut roundtrip);
             }
 
             assert_eq!(input, roundtrip, "VBMI roundtrip failed for seed {seed}");
         }
+    }
+
+    /// The width-generic VBMI untranspose must match the width-parameterized baseline for every
+    /// element width.
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_vbmi_untranspose_all_widths_match_baseline() {
+        fn check<T: FastLanes>() {
+            for seed in [0, 42, 123, 255] {
+                let input = generate_test_data(seed);
+                let mut baseline_out = [0u64; 16];
+                let mut vbmi_out = [0u64; 16];
+
+                untranspose_bits_baseline::<T>(&input, &mut baseline_out);
+                // SAFETY: guarded by `has_vbmi`.
+                unsafe { untranspose_bits_vbmi::<T>(&input, &mut vbmi_out) };
+
+                assert_eq!(
+                    baseline_out,
+                    vbmi_out,
+                    "VBMI untranspose != baseline for type={} seed={seed}",
+                    core::any::type_name::<T>()
+                );
+            }
+        }
+        if !has_vbmi() {
+            return;
+        }
+        check::<u8>();
+        check::<u16>();
+        check::<u32>();
+        check::<u64>();
     }
 }


### PR DESCRIPTION
## Summary

The x86 BMI2 and VBMI `untranspose_bits` kernels previously only implemented the `u64` (16-lane) mask transpose; `u8`/`u16`/`u32` fell back to the scalar path (per the `TODO(x86)` in `mod.rs`). This generalizes both kernels to **all** element widths, matching what the NEON kernel already does, and routes every width through them in the dispatcher.
