### PR TITLE
[experimental] Unify VBMI untranspose onto one vpermi2b kernel for all widths

### DIFF
--- a/benches/bit_transpose.rs
+++ b/benches/bit_transpose.rs
@@ -63,6 +63,7 @@ fn dispatch_untranspose<T: FastLanes>(bencher: Bencher) {
 mod x86 {
     use super::{bench_blocks, Bencher};
     use fastlanes::x86;
+    use fastlanes::FastLanes;
 
     #[divan::bench]
     fn bmi2_transpose(bencher: Bencher) {
@@ -73,13 +74,15 @@ mod x86 {
         bench_blocks(bencher, |i, o| unsafe { x86::transpose_bits_bmi2(i, o) });
     }
 
-    #[divan::bench]
-    fn bmi2_untranspose(bencher: Bencher) {
+    #[divan::bench(types = [u8, u16, u32, u64])]
+    fn bmi2_untranspose<T: FastLanes>(bencher: Bencher) {
         if !x86::has_bmi2() {
             return;
         }
         // SAFETY: guarded by `has_bmi2`.
-        bench_blocks(bencher, |i, o| unsafe { x86::untranspose_bits_bmi2(i, o) });
+        bench_blocks(bencher, |i, o| unsafe {
+            x86::untranspose_bits_bmi2::<T>(i, o);
+        });
     }
 
     #[divan::bench]
@@ -91,13 +94,15 @@ mod x86 {
         bench_blocks(bencher, |i, o| unsafe { x86::transpose_bits_vbmi(i, o) });
     }
 
-    #[divan::bench]
-    fn vbmi_untranspose(bencher: Bencher) {
+    #[divan::bench(types = [u8, u16, u32, u64])]
+    fn vbmi_untranspose<T: FastLanes>(bencher: Bencher) {
         if !x86::has_vbmi() {
             return;
         }
         // SAFETY: guarded by `has_vbmi`.
-        bench_blocks(bencher, |i, o| unsafe { x86::untranspose_bits_vbmi(i, o) });
+        bench_blocks(bencher, |i, o| unsafe {
+            x86::untranspose_bits_vbmi::<T>(i, o);
+        });
     }
 }
 
@@ -111,7 +116,7 @@ mod aarch64 {
     fn neon_transpose(bencher: Bencher) {
         // SAFETY: NEON is always available on aarch64.
         bench_blocks(bencher, |i, o| unsafe {
-            aarch64::transpose_bits_neon(i, o)
+            aarch64::transpose_bits_neon(i, o);
         });
     }
 
@@ -119,7 +124,7 @@ mod aarch64 {
     fn neon_untranspose<T: FastLanes>(bencher: Bencher) {
         // SAFETY: NEON is always available on aarch64.
         bench_blocks(bencher, |i, o| unsafe {
-            aarch64::untranspose_bits_neon::<T>(i, o)
+            aarch64::untranspose_bits_neon::<T>(i, o);
         });
     }
 }

--- a/src/bit_transpose/aarch64.rs
+++ b/src/bit_transpose/aarch64.rs
@@ -18,11 +18,11 @@ use core::arch::aarch64::vsubq_u8;
 
 use crate::bit_transpose::as_byte_array;
 use crate::bit_transpose::as_byte_array_mut;
+use crate::bit_transpose::group_tables;
 use crate::bit_transpose::TRANSPOSE_2X2;
 use crate::bit_transpose::TRANSPOSE_4X4;
 use crate::bit_transpose::TRANSPOSE_8X8;
 use crate::FastLanes;
-use crate::FL_ORDER;
 
 /// Gather indices for the first half from input[0..64] (low 4 bytes of each group).
 static GATHER_FIRST_LO: [[u8; 16]; 4] = [
@@ -172,58 +172,6 @@ pub unsafe fn transpose_bits_neon(input: &[u64; 16], output: &mut [u64; 16]) {
     }
 }
 
-/// Byte-gather indices that pull the 8 bytes of every group into contiguous group-major order
-/// for an element width of `tb` bits. Group `g = lhi * (tb/8) + hi` collects byte `llo` of its
-/// lane words from input byte `lhi*tb + hi + llo*(tb/8)`. See [`crate::scalar::untranspose_bits`].
-const fn gather_indices(tb: usize) -> [u8; 128] {
-    let bytes = tb / 8;
-    let mut idx = [0u8; 128];
-    let mut g = 0;
-    while g < 16 {
-        let lhi = g / bytes;
-        let hi = g % bytes;
-        let gather_base = lhi * tb + hi;
-        let mut llo = 0;
-        while llo < 8 {
-            idx[g * 8 + llo] = (gather_base + llo * bytes) as u8;
-            llo += 1;
-        }
-        g += 1;
-    }
-    idx
-}
-
-/// Byte-scatter indices applied after the per-group 8x8 transpose: transposed byte `g*8 + lo`
-/// lands at logical byte `FL_ORDER[hi]*2 + lhi + lo*16`. Expressed as a gather table for
-/// [`permute_128`]: `idx[logical_byte] = g*8 + lo`.
-const fn scatter_indices(tb: usize) -> [u8; 128] {
-    let bytes = tb / 8;
-    let mut idx = [0u8; 128];
-    let mut g = 0;
-    while g < 16 {
-        let lhi = g / bytes;
-        let hi = g % bytes;
-        let scatter_base = FL_ORDER[hi] * 2 + lhi;
-        let mut lo = 0;
-        while lo < 8 {
-            idx[scatter_base + lo * 16] = (g * 8 + lo) as u8;
-            lo += 1;
-        }
-        g += 1;
-    }
-    idx
-}
-
-static GATHER_8: [u8; 128] = gather_indices(8);
-static GATHER_16: [u8; 128] = gather_indices(16);
-static GATHER_32: [u8; 128] = gather_indices(32);
-static GATHER_64: [u8; 128] = gather_indices(64);
-
-static SCATTER_8: [u8; 128] = scatter_indices(8);
-static SCATTER_16: [u8; 128] = scatter_indices(16);
-static SCATTER_32: [u8; 128] = scatter_indices(32);
-static SCATTER_64: [u8; 128] = scatter_indices(64);
-
 /// Apply an arbitrary 128-byte gather permutation (`out[k] = src[idx[k]]`) using NEON TBL.
 ///
 /// `vqtbl4q_u8` only addresses 64 source bytes, returning 0 for indices `>= 64`. We split `src`
@@ -258,12 +206,7 @@ unsafe fn permute_128(src: &[u8; 128], idx: &[u8; 128]) -> [u8; 128] {
 #[inline]
 #[allow(unsafe_op_in_unsafe_fn)]
 pub unsafe fn untranspose_bits_neon<T: FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
-    let (gather_idx, scatter_idx): (&[u8; 128], &[u8; 128]) = match T::T {
-        8 => (&GATHER_8, &SCATTER_8),
-        16 => (&GATHER_16, &SCATTER_16),
-        32 => (&GATHER_32, &SCATTER_32),
-        _ => (&GATHER_64, &SCATTER_64),
-    };
+    let (gather_idx, scatter_idx) = group_tables::<T>();
 
     // Gather the 16 groups into contiguous group-major order.
     let gathered = permute_128(as_byte_array(input), gather_idx);

--- a/src/bit_transpose/aarch64.rs
+++ b/src/bit_transpose/aarch64.rs
@@ -18,7 +18,7 @@ use core::arch::aarch64::vsubq_u8;
 
 use crate::bit_transpose::as_byte_array;
 use crate::bit_transpose::as_byte_array_mut;
-use crate::bit_transpose::group_tables;
+use crate::bit_transpose::group_perm::group_tables;
 use crate::bit_transpose::TRANSPOSE_2X2;
 use crate::bit_transpose::TRANSPOSE_4X4;
 use crate::bit_transpose::TRANSPOSE_8X8;

--- a/src/bit_transpose/mod.rs
+++ b/src/bit_transpose/mod.rs
@@ -46,79 +46,72 @@ pub(crate) const TRANSPOSE_2X2: u64 = 0x00AA_00AA_00AA_00AA;
 pub(crate) const TRANSPOSE_4X4: u64 = 0x0000_CCCC_0000_CCCC;
 pub(crate) const TRANSPOSE_8X8: u64 = 0x0000_0000_F0F0_F0F0;
 
-/// Byte-gather indices that pull the 8 bytes of every group into contiguous group-major order
-/// for an element width of `tb` bits. Group `g = lhi * (tb/8) + hi` collects byte `llo` of its
-/// lane words from input byte `lhi*tb + hi + llo*(tb/8)`. See [`crate::bit_transpose::scalar::untranspose_bits`].
+/// Group-major gather/scatter permutation tables shared by the SIMD width-generic untranspose
+/// kernels (NEON and AVX-512 VBMI). Only built for the architectures that have such a kernel.
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-pub(crate) const fn gather_indices(tb: usize) -> [u8; 128] {
-    let bytes = tb / 8;
-    let mut idx = [0u8; 128];
-    let mut g = 0;
-    while g < 16 {
-        let lhi = g / bytes;
-        let hi = g % bytes;
-        let gather_base = lhi * tb + hi;
-        let mut llo = 0;
-        while llo < 8 {
-            idx[g * 8 + llo] = (gather_base + llo * bytes) as u8;
-            llo += 1;
+pub(crate) mod group_perm {
+    /// Byte-gather indices that pull the 8 bytes of every group into contiguous group-major order
+    /// for an element width of `tb` bits. Group `g = lhi * (tb/8) + hi` collects byte `llo` of its
+    /// lane words from input byte `lhi*tb + hi + llo*(tb/8)`. See
+    /// [`crate::bit_transpose::scalar::untranspose_bits`].
+    const fn gather_indices(tb: usize) -> [u8; 128] {
+        let bytes = tb / 8;
+        let mut idx = [0u8; 128];
+        let mut g = 0;
+        while g < 16 {
+            let lhi = g / bytes;
+            let hi = g % bytes;
+            let gather_base = lhi * tb + hi;
+            let mut llo = 0;
+            while llo < 8 {
+                idx[g * 8 + llo] = (gather_base + llo * bytes) as u8;
+                llo += 1;
+            }
+            g += 1;
         }
-        g += 1;
+        idx
     }
-    idx
-}
 
-/// Byte-scatter indices applied after the per-group 8x8 transpose: transposed byte `g*8 + lo`
-/// lands at logical byte `FL_ORDER[hi]*2 + lhi + lo*16`. Expressed as a gather table:
-/// `idx[logical_byte] = g*8 + lo`.
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-pub(crate) const fn scatter_indices(tb: usize) -> [u8; 128] {
-    let bytes = tb / 8;
-    let mut idx = [0u8; 128];
-    let mut g = 0;
-    while g < 16 {
-        let lhi = g / bytes;
-        let hi = g % bytes;
-        let scatter_base = crate::FL_ORDER[hi] * 2 + lhi;
-        let mut lo = 0;
-        while lo < 8 {
-            idx[scatter_base + lo * 16] = (g * 8 + lo) as u8;
-            lo += 1;
+    /// Byte-scatter indices applied after the per-group 8x8 transpose: transposed byte `g*8 + lo`
+    /// lands at logical byte `FL_ORDER[hi]*2 + lhi + lo*16`. Expressed as a gather table:
+    /// `idx[logical_byte] = g*8 + lo`.
+    const fn scatter_indices(tb: usize) -> [u8; 128] {
+        let bytes = tb / 8;
+        let mut idx = [0u8; 128];
+        let mut g = 0;
+        while g < 16 {
+            let lhi = g / bytes;
+            let hi = g % bytes;
+            let scatter_base = crate::FL_ORDER[hi] * 2 + lhi;
+            let mut lo = 0;
+            while lo < 8 {
+                idx[scatter_base + lo * 16] = (g * 8 + lo) as u8;
+                lo += 1;
+            }
+            g += 1;
         }
-        g += 1;
+        idx
     }
-    idx
-}
 
-/// Group-major gather tables, indexed by element width (bits). Shared by the NEON and AVX-512
-/// VBMI width-generic untranspose kernels.
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-pub(crate) static GATHER_8: [u8; 128] = gather_indices(8);
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-pub(crate) static GATHER_16: [u8; 128] = gather_indices(16);
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-pub(crate) static GATHER_32: [u8; 128] = gather_indices(32);
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-pub(crate) static GATHER_64: [u8; 128] = gather_indices(64);
+    static GATHER_8: [u8; 128] = gather_indices(8);
+    static GATHER_16: [u8; 128] = gather_indices(16);
+    static GATHER_32: [u8; 128] = gather_indices(32);
+    static GATHER_64: [u8; 128] = gather_indices(64);
 
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-pub(crate) static SCATTER_8: [u8; 128] = scatter_indices(8);
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-pub(crate) static SCATTER_16: [u8; 128] = scatter_indices(16);
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-pub(crate) static SCATTER_32: [u8; 128] = scatter_indices(32);
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-pub(crate) static SCATTER_64: [u8; 128] = scatter_indices(64);
+    static SCATTER_8: [u8; 128] = scatter_indices(8);
+    static SCATTER_16: [u8; 128] = scatter_indices(16);
+    static SCATTER_32: [u8; 128] = scatter_indices(32);
+    static SCATTER_64: [u8; 128] = scatter_indices(64);
 
-/// Select the `(gather, scatter)` group-major permutation tables for an element width.
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-#[inline]
-pub(crate) fn group_tables<T: crate::FastLanes>() -> (&'static [u8; 128], &'static [u8; 128]) {
-    match T::T {
-        8 => (&GATHER_8, &SCATTER_8),
-        16 => (&GATHER_16, &SCATTER_16),
-        32 => (&GATHER_32, &SCATTER_32),
-        _ => (&GATHER_64, &SCATTER_64),
+    /// Select the `(gather, scatter)` group-major permutation tables for an element width.
+    #[inline]
+    pub(crate) fn group_tables<T: crate::FastLanes>() -> (&'static [u8; 128], &'static [u8; 128]) {
+        match T::T {
+            8 => (&GATHER_8, &SCATTER_8),
+            16 => (&GATHER_16, &SCATTER_16),
+            32 => (&GATHER_32, &SCATTER_32),
+            _ => (&GATHER_64, &SCATTER_64),
+        }
     }
 }
 

--- a/src/bit_transpose/mod.rs
+++ b/src/bit_transpose/mod.rs
@@ -46,6 +46,82 @@ pub(crate) const TRANSPOSE_2X2: u64 = 0x00AA_00AA_00AA_00AA;
 pub(crate) const TRANSPOSE_4X4: u64 = 0x0000_CCCC_0000_CCCC;
 pub(crate) const TRANSPOSE_8X8: u64 = 0x0000_0000_F0F0_F0F0;
 
+/// Byte-gather indices that pull the 8 bytes of every group into contiguous group-major order
+/// for an element width of `tb` bits. Group `g = lhi * (tb/8) + hi` collects byte `llo` of its
+/// lane words from input byte `lhi*tb + hi + llo*(tb/8)`. See [`crate::bit_transpose::scalar::untranspose_bits`].
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+pub(crate) const fn gather_indices(tb: usize) -> [u8; 128] {
+    let bytes = tb / 8;
+    let mut idx = [0u8; 128];
+    let mut g = 0;
+    while g < 16 {
+        let lhi = g / bytes;
+        let hi = g % bytes;
+        let gather_base = lhi * tb + hi;
+        let mut llo = 0;
+        while llo < 8 {
+            idx[g * 8 + llo] = (gather_base + llo * bytes) as u8;
+            llo += 1;
+        }
+        g += 1;
+    }
+    idx
+}
+
+/// Byte-scatter indices applied after the per-group 8x8 transpose: transposed byte `g*8 + lo`
+/// lands at logical byte `FL_ORDER[hi]*2 + lhi + lo*16`. Expressed as a gather table:
+/// `idx[logical_byte] = g*8 + lo`.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+pub(crate) const fn scatter_indices(tb: usize) -> [u8; 128] {
+    let bytes = tb / 8;
+    let mut idx = [0u8; 128];
+    let mut g = 0;
+    while g < 16 {
+        let lhi = g / bytes;
+        let hi = g % bytes;
+        let scatter_base = crate::FL_ORDER[hi] * 2 + lhi;
+        let mut lo = 0;
+        while lo < 8 {
+            idx[scatter_base + lo * 16] = (g * 8 + lo) as u8;
+            lo += 1;
+        }
+        g += 1;
+    }
+    idx
+}
+
+/// Group-major gather tables, indexed by element width (bits). Shared by the NEON and AVX-512
+/// VBMI width-generic untranspose kernels.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+pub(crate) static GATHER_8: [u8; 128] = gather_indices(8);
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+pub(crate) static GATHER_16: [u8; 128] = gather_indices(16);
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+pub(crate) static GATHER_32: [u8; 128] = gather_indices(32);
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+pub(crate) static GATHER_64: [u8; 128] = gather_indices(64);
+
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+pub(crate) static SCATTER_8: [u8; 128] = scatter_indices(8);
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+pub(crate) static SCATTER_16: [u8; 128] = scatter_indices(16);
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+pub(crate) static SCATTER_32: [u8; 128] = scatter_indices(32);
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+pub(crate) static SCATTER_64: [u8; 128] = scatter_indices(64);
+
+/// Select the `(gather, scatter)` group-major permutation tables for an element width.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[inline]
+pub(crate) fn group_tables<T: crate::FastLanes>() -> (&'static [u8; 128], &'static [u8; 128]) {
+    match T::T {
+        8 => (&GATHER_8, &SCATTER_8),
+        16 => (&GATHER_16, &SCATTER_16),
+        32 => (&GATHER_32, &SCATTER_32),
+        _ => (&GATHER_64, &SCATTER_64),
+    }
+}
+
 /// Reinterpret a 1024-bit block (`[u64; 16]`) as its 128 little-endian bytes.
 #[inline]
 #[must_use]
@@ -133,18 +209,12 @@ pub fn transpose_bits(input: &[u64; 16], output: &mut [u64; 16]) {
 pub fn untranspose_bits<T: crate::FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
     #[cfg(target_arch = "x86_64")]
     {
-        // The BMI2/VBMI kernels currently only implement the `u64` (16-lane) transpose; other
-        // widths fall back to scalar.
-        //
-        // TODO(x86): add width-generic `untranspose_bits_{bmi2,vbmi}::<T>` kernels (mirroring the
-        // NEON `permute_128` + per-group 8x8 transpose approach in `aarch64.rs`) and route u8/u16/
-        // u32 through them here instead of the scalar fallback.
-        if T::T == 64 && detect_vbmi() {
+        if detect_vbmi() {
             // SAFETY: guarded by `detect_vbmi`.
-            unsafe { x86::untranspose_bits_vbmi(input, output) }
-        } else if T::T == 64 && detect_bmi2() {
+            unsafe { x86::untranspose_bits_vbmi::<T>(input, output) }
+        } else if detect_bmi2() {
             // SAFETY: guarded by `detect_bmi2`.
-            unsafe { x86::untranspose_bits_bmi2(input, output) }
+            unsafe { x86::untranspose_bits_bmi2::<T>(input, output) }
         } else {
             scalar::untranspose_bits::<T>(input, output);
         }

--- a/src/bit_transpose/x86.rs
+++ b/src/bit_transpose/x86.rs
@@ -211,11 +211,15 @@ pub unsafe fn transpose_bits_vbmi(input: &[u64; 16], output: &mut [u64; 16]) {
 
 /// Untranspose a `T`-width comparison mask (1024 bits) using AVX-512 VBMI.
 ///
-/// Regardless of width the 128 bytes factor into 16 groups of 8 bytes, each an independent 8x8
-/// bit transpose. The `T = 64` block keeps the original kernel (gather within each 64-byte half
-/// with `vpermb`, then scatter); narrower widths use the width-generic [`untranspose_bits_vbmi_lt64`]
-/// kernel whose groups span both halves. For `T = u64` this is the canonical `FastLanes` bit
-/// untranspose.
+/// Single width-generic kernel mirroring the NEON one: `vpermi2b` gathers the 16 eight-byte
+/// groups into group-major order across two ZMM registers (each 64-bit lane is one group), every
+/// lane is 8x8 bit-transposed in parallel, then a second pair of `vpermi2b` scatters the
+/// transposed groups to their logical byte positions. Only the per-width gather/scatter tables
+/// vary. For `T = u64` this is the canonical `FastLanes` bit untranspose.
+///
+/// Unlike the staged BMI2 branch in PR #145 this uses the uniform `vpermi2b` path for `u64` too
+/// (a group's 8 bytes happen to stay within one 64-byte half at this width, so the second source
+/// is unused, but the two-source form keeps a single code path).
 ///
 /// # Safety
 /// Requires AVX-512F, AVX-512BW, and AVX-512VBMI support. Check with [`has_vbmi`].
@@ -223,50 +227,6 @@ pub unsafe fn transpose_bits_vbmi(input: &[u64; 16], output: &mut [u64; 16]) {
 #[inline]
 #[allow(clippy::cast_ptr_alignment, unsafe_op_in_unsafe_fn)]
 pub unsafe fn untranspose_bits_vbmi<T: FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
-    // `T::T` is a compile-time constant, so this branch is resolved at monomorphization and the
-    // unused arm is eliminated. The `u64` arm is kept byte-identical to the original kernel.
-    if T::T != 64 {
-        untranspose_bits_vbmi_lt64::<T>(input, output);
-        return;
-    }
-
-    let input = as_byte_array(input);
-    let output = as_byte_array_mut(output);
-
-    // In the transposed layout the 8 bytes of a group are consecutive; this gather
-    // collects them into the eight u64 lanes of a ZMM register.
-    let gather_indices: [u8; 64] = SCATTER_8X8;
-    let idx = _mm512_loadu_si512(gather_indices.as_ptr().cast::<__m512i>());
-
-    for (half, groups) in [BASE_PATTERN_FIRST, BASE_PATTERN_SECOND].iter().enumerate() {
-        let in_half = _mm512_loadu_si512(input.as_ptr().add(half * 64).cast::<__m512i>());
-        let gathered = _mm512_permutexvar_epi8(idx, in_half);
-        let transposed = bit_transpose_8x8_zmm(gathered);
-
-        let mut lanes = [0u64; 8];
-        _mm512_storeu_si512(lanes.as_mut_ptr().cast::<__m512i>(), transposed);
-        for (group, &base) in groups.iter().enumerate() {
-            for row in 0..8 {
-                output[base + row * 16] = (lanes[group] >> (row * 8)) as u8;
-            }
-        }
-    }
-}
-
-/// Width-generic (`T::T < 64`) VBMI untranspose for the narrow comparison-mask widths.
-///
-/// Mirrors the width-generic NEON kernel: `vpermi2b` gathers the 16 eight-byte groups into
-/// group-major order across two ZMM registers (each 64-bit lane is one group), every lane is
-/// 8x8 bit-transposed in parallel, then a second pair of `vpermi2b` scatters the transposed
-/// groups to their logical byte positions. For these widths a group spans both 64-byte halves,
-/// so the two-source `vpermi2b` is required (unlike the single-source `vpermb` in the `u64` path).
-///
-/// # Safety
-/// Requires AVX-512F, AVX-512BW, and AVX-512VBMI support. Check with [`has_vbmi`].
-#[target_feature(enable = "avx512f", enable = "avx512bw", enable = "avx512vbmi")]
-#[inline]
-#[allow(clippy::cast_ptr_alignment, unsafe_op_in_unsafe_fn)]
-unsafe fn untranspose_bits_vbmi_lt64<T: FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
     let input = as_byte_array(input);
     let output = as_byte_array_mut(output);
     let (gather_idx, scatter_idx) = group_tables::<T>();

--- a/src/bit_transpose/x86.rs
+++ b/src/bit_transpose/x86.rs
@@ -16,7 +16,7 @@ use core::arch::x86_64::_pext_u64;
 
 use crate::bit_transpose::as_byte_array;
 use crate::bit_transpose::as_byte_array_mut;
-use crate::bit_transpose::group_tables;
+use crate::bit_transpose::group_perm::group_tables;
 use crate::bit_transpose::BASE_PATTERN_FIRST;
 use crate::bit_transpose::BASE_PATTERN_SECOND;
 use crate::bit_transpose::TRANSPOSE_2X2;

--- a/src/bit_transpose/x86.rs
+++ b/src/bit_transpose/x86.rs
@@ -16,11 +16,14 @@ use core::arch::x86_64::_pext_u64;
 
 use crate::bit_transpose::as_byte_array;
 use crate::bit_transpose::as_byte_array_mut;
+use crate::bit_transpose::group_tables;
 use crate::bit_transpose::BASE_PATTERN_FIRST;
 use crate::bit_transpose::BASE_PATTERN_SECOND;
 use crate::bit_transpose::TRANSPOSE_2X2;
 use crate::bit_transpose::TRANSPOSE_4X4;
 use crate::bit_transpose::TRANSPOSE_8X8;
+use crate::FastLanes;
+use crate::FL_ORDER;
 
 /// Check if BMI2 is available (requires the `std` feature for runtime detection).
 #[cfg(feature = "std")]
@@ -75,28 +78,36 @@ pub unsafe fn transpose_bits_bmi2(input: &[u64; 16], output: &mut [u64; 16]) {
     }
 }
 
-/// Untranspose 1024 bits using BMI2 `PDEP`.
+/// Untranspose a `T`-width comparison mask (1024 bits) using BMI2 `PDEP`.
 ///
-/// For each output group of 8 bytes at stride 16, `PDEP` deposits the 8 input bytes
-/// into their respective bit positions, then the group is scattered out at once.
+/// Regardless of width the 128 bytes factor into 16 groups of 8 bytes, each an independent 8x8
+/// bit transpose (see [`crate::bit_transpose::scalar::untranspose_bits`]). The width only changes
+/// the gather stride and the scatter base. For each group we gather its 8 bytes (at stride
+/// `T::T / 8`) and use `PDEP` to deposit byte `llo` into bit-position `llo` of all 8 packed
+/// output bytes — which is exactly the 8x8 bit transpose — then scatter the group at stride 16.
+/// For `T = u64` this is the canonical `FastLanes` bit untranspose.
 ///
 /// # Safety
 /// Requires BMI2 support. Check with [`has_bmi2`] before calling.
 #[target_feature(enable = "bmi2")]
 #[inline]
 #[allow(unsafe_op_in_unsafe_fn)]
-pub unsafe fn untranspose_bits_bmi2(input: &[u64; 16], output: &mut [u64; 16]) {
+pub unsafe fn untranspose_bits_bmi2<T: FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
     let input = as_byte_array(input);
     let output = as_byte_array_mut(output);
 
-    for (half, groups) in [BASE_PATTERN_FIRST, BASE_PATTERN_SECOND].iter().enumerate() {
-        for (group, &base) in groups.iter().enumerate() {
+    let bytes = T::T / 8;
+    let lhi_count = 128 / T::T;
+    for lhi in 0..lhi_count {
+        for hi in 0..bytes {
+            let gather_base = lhi * T::T + hi;
             let mut v = 0u64;
-            for (bit, &mask) in BIT_MASKS.iter().enumerate() {
-                v |= _pdep_u64(u64::from(input[half * 64 + bit * 8 + group]), mask);
+            for (llo, &mask) in BIT_MASKS.iter().enumerate() {
+                v |= _pdep_u64(u64::from(input[gather_base + llo * bytes]), mask);
             }
+            let scatter_base = FL_ORDER[hi] * 2 + lhi;
             for row in 0..8 {
-                output[base + row * 16] = (v >> (row * 8)) as u8;
+                output[scatter_base + row * 16] = (v >> (row * 8)) as u8;
             }
         }
     }
@@ -198,14 +209,27 @@ pub unsafe fn transpose_bits_vbmi(input: &[u64; 16], output: &mut [u64; 16]) {
     }
 }
 
-/// Untranspose 1024 bits using AVX-512 VBMI for vectorized gather.
+/// Untranspose a `T`-width comparison mask (1024 bits) using AVX-512 VBMI.
+///
+/// Regardless of width the 128 bytes factor into 16 groups of 8 bytes, each an independent 8x8
+/// bit transpose. The `T = 64` block keeps the original kernel (gather within each 64-byte half
+/// with `vpermb`, then scatter); narrower widths use the width-generic [`untranspose_bits_vbmi_lt64`]
+/// kernel whose groups span both halves. For `T = u64` this is the canonical `FastLanes` bit
+/// untranspose.
 ///
 /// # Safety
 /// Requires AVX-512F, AVX-512BW, and AVX-512VBMI support. Check with [`has_vbmi`].
 #[target_feature(enable = "avx512f", enable = "avx512bw", enable = "avx512vbmi")]
 #[inline]
 #[allow(clippy::cast_ptr_alignment, unsafe_op_in_unsafe_fn)]
-pub unsafe fn untranspose_bits_vbmi(input: &[u64; 16], output: &mut [u64; 16]) {
+pub unsafe fn untranspose_bits_vbmi<T: FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
+    // `T::T` is a compile-time constant, so this branch is resolved at monomorphization and the
+    // unused arm is eliminated. The `u64` arm is kept byte-identical to the original kernel.
+    if T::T != 64 {
+        untranspose_bits_vbmi_lt64::<T>(input, output);
+        return;
+    }
+
     let input = as_byte_array(input);
     let output = as_byte_array_mut(output);
 
@@ -229,6 +253,51 @@ pub unsafe fn untranspose_bits_vbmi(input: &[u64; 16], output: &mut [u64; 16]) {
     }
 }
 
+/// Width-generic (`T::T < 64`) VBMI untranspose for the narrow comparison-mask widths.
+///
+/// Mirrors the width-generic NEON kernel: `vpermi2b` gathers the 16 eight-byte groups into
+/// group-major order across two ZMM registers (each 64-bit lane is one group), every lane is
+/// 8x8 bit-transposed in parallel, then a second pair of `vpermi2b` scatters the transposed
+/// groups to their logical byte positions. For these widths a group spans both 64-byte halves,
+/// so the two-source `vpermi2b` is required (unlike the single-source `vpermb` in the `u64` path).
+///
+/// # Safety
+/// Requires AVX-512F, AVX-512BW, and AVX-512VBMI support. Check with [`has_vbmi`].
+#[target_feature(enable = "avx512f", enable = "avx512bw", enable = "avx512vbmi")]
+#[inline]
+#[allow(clippy::cast_ptr_alignment, unsafe_op_in_unsafe_fn)]
+unsafe fn untranspose_bits_vbmi_lt64<T: FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
+    let input = as_byte_array(input);
+    let output = as_byte_array_mut(output);
+    let (gather_idx, scatter_idx) = group_tables::<T>();
+
+    let in_lo = _mm512_loadu_si512(input.as_ptr().cast::<__m512i>());
+    let in_hi = _mm512_loadu_si512(input.as_ptr().add(64).cast::<__m512i>());
+
+    // Gather the 16 groups (8 bytes each) into group-major order: groups 0..7 in `grp0`,
+    // groups 8..15 in `grp1`. Each 64-bit lane holds one group's 8 bytes.
+    let g_lo = _mm512_loadu_si512(gather_idx.as_ptr().cast::<__m512i>());
+    let g_hi = _mm512_loadu_si512(gather_idx.as_ptr().add(64).cast::<__m512i>());
+    let grp0 = _mm512_permutex2var_epi8(in_lo, g_lo, in_hi);
+    let grp1 = _mm512_permutex2var_epi8(in_lo, g_hi, in_hi);
+
+    // 8x8 bit-transpose every group (all 8 lanes of each register in parallel).
+    let t0 = bit_transpose_8x8_zmm(grp0);
+    let t1 = bit_transpose_8x8_zmm(grp1);
+
+    // Scatter the transposed groups to their logical byte positions.
+    let s_lo = _mm512_loadu_si512(scatter_idx.as_ptr().cast::<__m512i>());
+    let s_hi = _mm512_loadu_si512(scatter_idx.as_ptr().add(64).cast::<__m512i>());
+    _mm512_storeu_si512(
+        output.as_mut_ptr().cast::<__m512i>(),
+        _mm512_permutex2var_epi8(t0, s_lo, t1),
+    );
+    _mm512_storeu_si512(
+        output.as_mut_ptr().add(64).cast::<__m512i>(),
+        _mm512_permutex2var_epi8(t0, s_hi, t1),
+    );
+}
+
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "std")]
@@ -237,6 +306,8 @@ mod tests {
     use crate::bit_transpose::generate_test_data;
     #[cfg(feature = "std")]
     use crate::bit_transpose::transpose_bits_baseline;
+    #[cfg(feature = "std")]
+    use crate::bit_transpose::untranspose_bits_baseline;
 
     #[cfg(feature = "std")]
     #[test]
@@ -274,11 +345,43 @@ mod tests {
             // SAFETY: guarded by `has_bmi2`.
             unsafe {
                 transpose_bits_bmi2(&input, &mut transposed);
-                untranspose_bits_bmi2(&transposed, &mut roundtrip);
+                untranspose_bits_bmi2::<u64>(&transposed, &mut roundtrip);
             }
 
             assert_eq!(input, roundtrip, "BMI2 roundtrip failed for seed {seed}");
         }
+    }
+
+    /// The width-generic BMI2 untranspose must match the width-parameterized baseline for every
+    /// element width.
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_bmi2_untranspose_all_widths_match_baseline() {
+        fn check<T: FastLanes>() {
+            for seed in [0, 42, 123, 255] {
+                let input = generate_test_data(seed);
+                let mut baseline_out = [0u64; 16];
+                let mut bmi2_out = [0u64; 16];
+
+                untranspose_bits_baseline::<T>(&input, &mut baseline_out);
+                // SAFETY: guarded by `has_bmi2`.
+                unsafe { untranspose_bits_bmi2::<T>(&input, &mut bmi2_out) };
+
+                assert_eq!(
+                    baseline_out,
+                    bmi2_out,
+                    "BMI2 untranspose != baseline for type={} seed={seed}",
+                    core::any::type_name::<T>()
+                );
+            }
+        }
+        if !has_bmi2() {
+            return;
+        }
+        check::<u8>();
+        check::<u16>();
+        check::<u32>();
+        check::<u64>();
     }
 
     #[cfg(feature = "std")]
@@ -317,10 +420,42 @@ mod tests {
             // SAFETY: guarded by `has_vbmi`.
             unsafe {
                 transpose_bits_vbmi(&input, &mut transposed);
-                untranspose_bits_vbmi(&transposed, &mut roundtrip);
+                untranspose_bits_vbmi::<u64>(&transposed, &mut roundtrip);
             }
 
             assert_eq!(input, roundtrip, "VBMI roundtrip failed for seed {seed}");
         }
+    }
+
+    /// The width-generic VBMI untranspose must match the width-parameterized baseline for every
+    /// element width.
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_vbmi_untranspose_all_widths_match_baseline() {
+        fn check<T: FastLanes>() {
+            for seed in [0, 42, 123, 255] {
+                let input = generate_test_data(seed);
+                let mut baseline_out = [0u64; 16];
+                let mut vbmi_out = [0u64; 16];
+
+                untranspose_bits_baseline::<T>(&input, &mut baseline_out);
+                // SAFETY: guarded by `has_vbmi`.
+                unsafe { untranspose_bits_vbmi::<T>(&input, &mut vbmi_out) };
+
+                assert_eq!(
+                    baseline_out,
+                    vbmi_out,
+                    "VBMI untranspose != baseline for type={} seed={seed}",
+                    core::any::type_name::<T>()
+                );
+            }
+        }
+        if !has_vbmi() {
+            return;
+        }
+        check::<u8>();
+        check::<u16>();
+        check::<u32>();
+        check::<u64>();
     }
 }


### PR DESCRIPTION
## ⚠️ Disclaimer — experimental, NOT validated on real AVX-512VBMI hardware

This PR changes the **u64 VBMI untranspose kernel**. It could **not be executed on real `avx512vbmi` hardware** in the dev/CI environment available to me:

- the host CPU lacks `avx512vbmi` (so the `has_vbmi()`-gated tests skip);
- `qemu-user` here cannot execute AVX-512 in user mode (TCG faults on even basic AVX-512F — XSAVE/ZMM state unsupported in this build);
- Intel SDE was not reachable (download blocked).

So correctness here rests on **cross-compilation** + **structural equivalence**, not execution — see "Validation" below. **Do not merge until it has been run on a real `avx512vbmi` machine** (the existing `test_vbmi_untranspose_all_widths_match_baseline` test will exercise it there). Stacked on #145; review/merge that first.

## What changed

Stacked on top of #145. That PR intentionally kept the `u64` VBMI path byte-identical to the original kernel (`vpermb` gather within a 64-byte half + a scatter the compiler vectorizes), behind a compile-time `T::T == 64` branch, because VBMI couldn't be benchmarked.

This PR removes that special-case (and the `_lt64` helper) so **all** widths — including `u64` — flow through the single width-generic kernel:

```
vpermi2b gather (16 groups → group-major)  →  8x8 bit-transpose (zmm)  →  vpermi2b scatter
```

Only the per-width `group_perm` gather/scatter tables differ. For `u64` each group's 8 bytes stay within one 64-byte half, so the second `vpermi2b` source is unused — the two-source form just keeps one code path.

Net diff: **−40 lines** in `x86.rs`, one kernel instead of two.

## Validation (no real-hardware execution)

- **Cross-compiles** cleanly, including `RUSTFLAGS="-C target-feature=+avx512f,+avx512bw,+avx512vbmi"` (forces VBMI codegen). Confirmed via `--emit asm` that `u64` now emits `vpermi2b` gather + `vpermi2b` scatter (no `vpermb`, no scalar scatter).
- **Structural equivalence:** the kernel is identical to the narrow-width VBMI path already in #145, and uses the same `GATHER_64`/`SCATTER_64` tables that the NEON `untranspose_bits_neon::<u64>` all-widths test executes and validates on aarch64 CI. The scalar/BMI2 all-widths tests cover the same tables on x86.
- `cargo test --features std` (155) + clippy clean on x86_64 (std + no_std) and aarch64.

## Why it's worth considering

One uniform kernel (matches the NEON structure), no compile-time width branch, ~40 fewer lines. Permute-op count is unchanged vs the #145 u64 path (4 permutes either way); the gather becomes two-source `vpermi2b` instead of single-source `vpermb`, which is throughput-equivalent on Ice Lake / Zen 4 — but that should be confirmed on hardware before merging.

https://claude.ai/code/session_01ATBvsrFw3eAPgcZnrqpMPS

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATBvsrFw3eAPgcZnrqpMPS)_