### PR TITLE
Remove array ref to reduce code size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ default = []
 std = []
 
 [dependencies]
-arrayref = "0.3.7"
 const_for = "0.1.4"
 core_detect = "1.0.0"
 num-traits = "0.2.19"

--- a/src/bitpacking.rs
+++ b/src/bitpacking.rs
@@ -1,4 +1,3 @@
-use arrayref::{array_mut_ref, array_ref};
 use const_for::const_for;
 use core::mem::size_of;
 use paste::paste;
@@ -89,8 +88,8 @@ macro_rules! impl_packing {
                         #(W => {
                             const B: usize = 1024 * W / <$T>::T;
                             Self::pack::<W, B>(
-                                array_ref![input, 0, 1024],
-                                array_mut_ref![output, 0, B],
+                                unsafe { crate::as_array_unchecked(input) },
+                                unsafe { crate::as_array_mut_unchecked(output) },
                             )
                         },)*
                         // seq_t has exclusive upper bound
@@ -99,8 +98,8 @@ macro_rules! impl_packing {
                             const W: usize = <$T>::T;
                             const B: usize = 1024;
                             Self::pack::<W, B>(
-                                array_ref![input, 0, 1024],
-                                array_mut_ref![output, 0, 1024],
+                                unsafe { crate::as_array_unchecked(input) },
+                                unsafe { crate::as_array_mut_unchecked(output) },
                             )
                         },
                         _ => unreachable!("Unsupported width: {}", width)
@@ -137,8 +136,8 @@ macro_rules! impl_packing {
                         #(W => {
                             const B: usize = 1024 * W / <$T>::T;
                             Self::unpack::<W, B>(
-                                array_ref![input, 0, B],
-                                array_mut_ref![output, 0, 1024],
+                                unsafe { crate::as_array_unchecked(input) },
+                                unsafe { crate::as_array_mut_unchecked(output) },
                             )
                         },)*
                         // seq_t has exclusive upper bound
@@ -146,8 +145,8 @@ macro_rules! impl_packing {
                             const W: usize = <$T>::T;
                             const B: usize = 1024;
                             Self::unpack::<W, B>(
-                                array_ref![input, 0, 1024],
-                                array_mut_ref![output, 0, 1024],
+                                unsafe { crate::as_array_unchecked(input) },
+                                unsafe { crate::as_array_mut_unchecked(output) },
                             )
                         },
                         _ => unreachable!("Unsupported width: {}", width)
@@ -219,13 +218,13 @@ macro_rules! impl_packing {
                     match width {
                         #(W => {
                             const B: usize = 1024 * W / T;
-                            return <$T>::unpack_single::<W, B>(array_ref![packed, 0, B], index);
+                            return <$T>::unpack_single::<W, B>(unsafe { crate::as_array_unchecked(packed) }, index);
                         },)*
                         // seq_t has exclusive upper bound
                         T => {
                             const W: usize = T;
                             const B: usize = 1024;
-                            return <$T>::unpack_single::<W, B>(array_ref![packed, 0, 1024], index);
+                            return <$T>::unpack_single::<W, B>(unsafe { crate::as_array_unchecked(packed) }, index);
                         },
                         _ => unreachable!("Unsupported width: {}", width)
                     }

--- a/src/bitpacking_cmp.rs
+++ b/src/bitpacking_cmp.rs
@@ -119,7 +119,7 @@ macro_rules! impl_packing_compare {
                         #(W => {
                             const B: usize = 1024 * W / <$T>::T;
                             Self::unpack_cmp::<W, B, V, F>(
-                                arrayref::array_ref![input, 0, 1024 * W / <$T>::T],
+                                unsafe { crate::as_array_unchecked(input) },
                                 output,
                                 comparison,
                                 value

--- a/src/ffor.rs
+++ b/src/ffor.rs
@@ -1,5 +1,4 @@
 use crate::{pack, seq_t, supported_bit_width, unpack, BitPacking, FastLanes};
-use arrayref::{array_mut_ref, array_ref};
 use paste::paste;
 
 pub trait FoR: BitPacking {
@@ -80,9 +79,9 @@ macro_rules! impl_for {
                         #(W => {
                             const B: usize = 1024 * W / <$T>::T;
                             Self::unfor_pack::<W, B>(
-                                array_ref![input, 0, B],
+                                unsafe { crate::as_array_unchecked(input) },
                                 reference,
-                                array_mut_ref![output, 0, 1024],
+                                unsafe { crate::as_array_mut_unchecked(output) },
                             )
                         },)*
                         // seq_t has exclusive upper bound
@@ -90,9 +89,9 @@ macro_rules! impl_for {
                             const W: usize = <$T>::T;
                             const B: usize = 1024;
                             Self::unfor_pack::<W, B>(
-                                array_ref![input, 0, 1024],
+                                unsafe { crate::as_array_unchecked(input) },
                                 reference,
-                                array_mut_ref![output, 0, 1024],
+                                unsafe { crate::as_array_mut_unchecked(output) },
                             )
                         },
                         _ => unreachable!("Unsupported width: {}", width)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,30 @@ impl FastLanes for u16 {}
 impl FastLanes for u32 {}
 impl FastLanes for u64 {}
 
+/// Reinterprets the first `N` elements of `slice` as a fixed-size array reference.
+///
+/// # Safety
+/// `slice.len()` must be at least `N`. This is checked only with `debug_assert!`.
+#[inline]
+pub(crate) unsafe fn as_array_unchecked<T, const N: usize>(slice: &[T]) -> &[T; N] {
+    debug_assert!(slice.len() >= N);
+    // SAFETY: the caller guarantees `slice` has at least `N` elements, and `[T; N]`
+    // has the same alignment as `T`.
+    unsafe { &*slice.as_ptr().cast::<[T; N]>() }
+}
+
+/// Reinterprets the first `N` elements of `slice` as a mutable fixed-size array reference.
+///
+/// # Safety
+/// `slice.len()` must be at least `N`. This is checked only with `debug_assert!`.
+#[inline]
+pub(crate) unsafe fn as_array_mut_unchecked<T, const N: usize>(slice: &mut [T]) -> &mut [T; N] {
+    debug_assert!(slice.len() >= N);
+    // SAFETY: the caller guarantees `slice` has at least `N` elements, and `[T; N]`
+    // has the same alignment as `T`.
+    unsafe { &mut *slice.as_mut_ptr().cast::<[T; N]>() }
+}
+
 // Macro for repeating a code block bit_size_of::<T> times.
 #[macro_export]
 macro_rules! seq_t {


### PR DESCRIPTION
Build times are basically the same, but the rlib is 3.9MB instead of 5.4MB