### PR TITLE
Add libc debug symbols to codspeed runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-rust
 
+      - name: Install libc debug symbols
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libc6-dbg
+
       - name: Install Codspeed
         shell: bash
         run: cargo install --force cargo-codspeed --locked


### PR DESCRIPTION
Just to get better visibility into some of the underlying code. 