### PR TITLE
Mark RLE encode/decode as unsafe due to index bounds requirements

### DIFF
--- a/benches/rle.rs
+++ b/benches/rle.rs
@@ -17,7 +17,8 @@ fn rle_encode_u32(bencher: Bencher) {
 
     bencher.bench_local(|| {
         // SAFETY: all arguments are 1024-element arrays.
-        let unique_count = unsafe { u32::encode(black_box(&input), &mut rle_vals, &mut rle_idxs) };
+        let unique_count =
+            unsafe { u32::encode_unchecked(black_box(&input), &mut rle_vals, &mut rle_idxs) };
         black_box(unique_count);
     });
 }
@@ -28,14 +29,14 @@ fn rle_decode_u32(bencher: Bencher) {
     let mut rle_vals = [0u32; 1024];
     let mut rle_idxs = [0u16; 1024];
     // SAFETY: all arguments are 1024-element arrays.
-    let unique_count = unsafe { u32::encode(&input, &mut rle_vals, &mut rle_idxs) };
+    let unique_count = unsafe { u32::encode_unchecked(&input, &mut rle_vals, &mut rle_idxs) };
 
     let mut output = [0u32; 1024];
 
     bencher.bench_local(|| {
-        // SAFETY: `encode` only writes indices below the returned `unique_count`.
+        // SAFETY: `encode_unchecked` only writes indices below the returned `unique_count`.
         unsafe {
-            u32::decode(
+            u32::decode_unchecked(
                 black_box(&rle_vals[..unique_count]),
                 black_box(&rle_idxs),
                 &mut output,
@@ -60,8 +61,9 @@ fn rle_throughput_encode_32(bencher: Bencher) {
             let input_batch = array_ref![input_data, batch_start, 1024];
 
             // SAFETY: all arguments are 1024-element arrays.
-            let unique_count =
-                unsafe { u32::encode(black_box(input_batch), &mut rle_vals, &mut rle_idxs) };
+            let unique_count = unsafe {
+                u32::encode_unchecked(black_box(input_batch), &mut rle_vals, &mut rle_idxs)
+            };
             black_box(unique_count);
         }
     });
@@ -83,16 +85,17 @@ fn rle_throughput_decode_32(bencher: Bencher) {
         let mut rle_vals = [0u32; 1024];
         let mut rle_idxs = [0u16; 1024];
         // SAFETY: all arguments are 1024-element arrays.
-        let unique_count = unsafe { u32::encode(&input_batch, &mut rle_vals, &mut rle_idxs) };
+        let unique_count =
+            unsafe { u32::encode_unchecked(&input_batch, &mut rle_vals, &mut rle_idxs) };
         encoded_batches.push((rle_vals, rle_idxs, unique_count));
     }
 
     with_counter!(bencher, input_data.len() * std::mem::size_of::<u32>()).bench_local(|| {
         let mut output = [0u32; 1024];
         for (rle_vals, rle_idxs, unique_count) in &encoded_batches {
-            // SAFETY: `encode` only writes indices below the returned `unique_count`.
+            // SAFETY: `encode_unchecked` only writes indices below the returned `unique_count`.
             unsafe {
-                u32::decode(
+                u32::decode_unchecked(
                     black_box(&rle_vals[..*unique_count]),
                     black_box(rle_idxs),
                     &mut output,

--- a/benches/rle.rs
+++ b/benches/rle.rs
@@ -16,7 +16,8 @@ fn rle_encode_u32(bencher: Bencher) {
     let mut rle_idxs = [0u16; 1024];
 
     bencher.bench_local(|| {
-        let unique_count = u32::encode(black_box(&input), &mut rle_vals, &mut rle_idxs);
+        // SAFETY: all arguments are 1024-element arrays.
+        let unique_count = unsafe { u32::encode(black_box(&input), &mut rle_vals, &mut rle_idxs) };
         black_box(unique_count);
     });
 }
@@ -26,7 +27,8 @@ fn rle_decode_u32(bencher: Bencher) {
     let input: [u32; 1024] = std::array::from_fn(|i| (i / 100 + 1) as u32);
     let mut rle_vals = [0u32; 1024];
     let mut rle_idxs = [0u16; 1024];
-    let unique_count = u32::encode(&input, &mut rle_vals, &mut rle_idxs);
+    // SAFETY: all arguments are 1024-element arrays.
+    let unique_count = unsafe { u32::encode(&input, &mut rle_vals, &mut rle_idxs) };
 
     let mut output = [0u32; 1024];
 
@@ -57,7 +59,9 @@ fn rle_throughput_encode_32(bencher: Bencher) {
             let batch_start = batch * 1024;
             let input_batch = array_ref![input_data, batch_start, 1024];
 
-            let unique_count = u32::encode(black_box(input_batch), &mut rle_vals, &mut rle_idxs);
+            // SAFETY: all arguments are 1024-element arrays.
+            let unique_count =
+                unsafe { u32::encode(black_box(input_batch), &mut rle_vals, &mut rle_idxs) };
             black_box(unique_count);
         }
     });
@@ -78,7 +82,8 @@ fn rle_throughput_decode_32(bencher: Bencher) {
 
         let mut rle_vals = [0u32; 1024];
         let mut rle_idxs = [0u16; 1024];
-        let unique_count = u32::encode(&input_batch, &mut rle_vals, &mut rle_idxs);
+        // SAFETY: all arguments are 1024-element arrays.
+        let unique_count = unsafe { u32::encode(&input_batch, &mut rle_vals, &mut rle_idxs) };
         encoded_batches.push((rle_vals, rle_idxs, unique_count));
     }
 

--- a/benches/rle.rs
+++ b/benches/rle.rs
@@ -31,11 +31,14 @@ fn rle_decode_u32(bencher: Bencher) {
     let mut output = [0u32; 1024];
 
     bencher.bench_local(|| {
-        u32::decode(
-            black_box(&rle_vals[..unique_count]),
-            black_box(&rle_idxs),
-            &mut output,
-        );
+        // SAFETY: `encode` only writes indices below the returned `unique_count`.
+        unsafe {
+            u32::decode(
+                black_box(&rle_vals[..unique_count]),
+                black_box(&rle_idxs),
+                &mut output,
+            );
+        }
         black_box(&output);
     });
 }
@@ -82,11 +85,14 @@ fn rle_throughput_decode_32(bencher: Bencher) {
     with_counter!(bencher, input_data.len() * std::mem::size_of::<u32>()).bench_local(|| {
         let mut output = [0u32; 1024];
         for (rle_vals, rle_idxs, unique_count) in &encoded_batches {
-            u32::decode(
-                black_box(&rle_vals[..*unique_count]),
-                black_box(rle_idxs),
-                &mut output,
-            );
+            // SAFETY: `encode` only writes indices below the returned `unique_count`.
+            unsafe {
+                u32::decode(
+                    black_box(&rle_vals[..*unique_count]),
+                    black_box(rle_idxs),
+                    &mut output,
+                );
+            }
             black_box(&output);
         }
     });

--- a/src/rle.rs
+++ b/src/rle.rs
@@ -6,7 +6,15 @@ pub trait RLE: Sized {
     ///
     /// # Returns
     /// The number of run values in the dictionary
-    fn encode(
+    ///
+    /// # Safety
+    ///
+    /// - All three arguments must be valid for 1024 elements, as their types already
+    ///   guarantee.
+    ///
+    /// Implementations perform unchecked buffer accesses that rely on these bounds; they are
+    /// checked only with `debug_assert` (i.e., not checked on release builds).
+    unsafe fn encode(
         input: &[Self; 1024],
         rle_vals: &mut [Self; 1024],
         rle_idxs: &mut [u16; 1024],
@@ -29,7 +37,7 @@ pub trait RLE: Sized {
 
 impl<T: PartialEq + Copy> RLE for T {
     #[inline(never)]
-    fn encode(
+    unsafe fn encode(
         input: &[Self; 1024],
         rle_vals: &mut [Self; 1024],
         rle_idxs: &mut [u16; 1024],
@@ -45,6 +53,9 @@ impl<T: PartialEq + Copy> RLE for T {
         for i in 1..1024 {
             let cur_val = unsafe { *input.get_unchecked(i) };
             if cur_val != prev_val {
+                // SAFETY: `rle_val_idx` increments at most once per element, so it stays
+                // below 1024.
+                debug_assert!(rle_val_idx < rle_vals.len());
                 unsafe { *rle_vals.get_unchecked_mut(rle_val_idx) = cur_val };
                 rle_val_idx += 1;
                 pos_val += 1;
@@ -79,7 +90,8 @@ mod test {
         let mut rle_vals = [0u32; 1024];
         let mut rle_idxs = [0u16; 1024];
 
-        let unique_count = u32::encode(&input, &mut rle_vals, &mut rle_idxs);
+        // SAFETY: all arguments are 1024-element arrays.
+        let unique_count = unsafe { u32::encode(&input, &mut rle_vals, &mut rle_idxs) };
 
         assert_eq!(unique_count, 11);
     }
@@ -90,7 +102,8 @@ mod test {
         let mut rle_vals = [0u32; 1024];
         let mut rle_idxs = [0u16; 1024];
 
-        let unique_count = u32::encode(&input, &mut rle_vals, &mut rle_idxs);
+        // SAFETY: all arguments are 1024-element arrays.
+        let unique_count = unsafe { u32::encode(&input, &mut rle_vals, &mut rle_idxs) };
 
         // Check that RLE values are 1, 2, 3, ..., 11
         for i in 0..unique_count {
@@ -104,7 +117,8 @@ mod test {
         let mut rle_vals = [0u32; 1024];
         let mut rle_idxs = [0u16; 1024];
 
-        u32::encode(&input, &mut rle_vals, &mut rle_idxs);
+        // SAFETY: all arguments are 1024-element arrays.
+        unsafe { u32::encode(&input, &mut rle_vals, &mut rle_idxs) };
 
         for i in 0..100 {
             assert_eq!(rle_idxs[i], 0);
@@ -125,7 +139,8 @@ mod test {
         let mut rle_vals = [0u16; 1024];
         let mut rle_idxs = [0u16; 1024];
 
-        let unique_count = u16::encode(&input, &mut rle_vals, &mut rle_idxs);
+        // SAFETY: all arguments are 1024-element arrays.
+        let unique_count = unsafe { u16::encode(&input, &mut rle_vals, &mut rle_idxs) };
 
         assert_eq!(unique_count, 1);
         assert_eq!(rle_vals[0], 42);
@@ -142,7 +157,8 @@ mod test {
         let mut rle_vals = [0u8; 1024];
         let mut rle_idxs = [0u16; 1024];
 
-        let unique_count = u8::encode(&input, &mut rle_vals, &mut rle_idxs);
+        // SAFETY: all arguments are 1024-element arrays.
+        let unique_count = unsafe { u8::encode(&input, &mut rle_vals, &mut rle_idxs) };
 
         // RLE creates a new dictionary entry every time the value changes,
         // not when we encounter a new unique value.
@@ -155,7 +171,8 @@ mod test {
 
         let mut rle_vals = [0u8; 1024];
         let mut rle_idxs = [0u16; 1024];
-        let unique_count = u8::encode(&input, &mut rle_vals, &mut rle_idxs);
+        // SAFETY: all arguments are 1024-element arrays.
+        let unique_count = unsafe { u8::encode(&input, &mut rle_vals, &mut rle_idxs) };
 
         let mut decoded = [0u8; 1024];
         // SAFETY: `encode` only writes indices below the returned `unique_count`.

--- a/src/rle.rs
+++ b/src/rle.rs
@@ -15,7 +15,14 @@ pub trait RLE: Sized {
     /// Decode RLE-encoded data back to original values
     ///
     /// Takes the dictionary of run values and indices, reconstructing the original array
-    fn decode<I>(rle_vals: &[Self], rle_idxs: &[I; 1024], output: &mut [Self; 1024])
+    ///
+    /// # Safety
+    ///
+    /// - Every element of `rle_idxs`, converted via `Into<usize>`, must be less than
+    ///   `rle_vals.len()`.
+    ///
+    /// This is checked only with `debug_assert` (i.e., not checked on release builds).
+    unsafe fn decode<I>(rle_vals: &[Self], rle_idxs: &[I; 1024], output: &mut [Self; 1024])
     where
         I: Copy + Into<usize>;
 }
@@ -50,11 +57,13 @@ impl<T: PartialEq + Copy> RLE for T {
     }
 
     #[inline(never)]
-    fn decode<I>(rle_vals: &[Self], rle_idxs: &[I; 1024], output: &mut [Self; 1024])
+    unsafe fn decode<I>(rle_vals: &[Self], rle_idxs: &[I; 1024], output: &mut [Self; 1024])
     where
         I: Copy + Into<usize>,
     {
         for (idx, output) in rle_idxs.iter().zip(output.iter_mut()) {
+            debug_assert!((*idx).into() < rle_vals.len());
+            // SAFETY: the caller guarantees every index is less than `rle_vals.len()`.
             *output = unsafe { *rle_vals.get_unchecked((*idx).into()) };
         }
     }
@@ -149,7 +158,8 @@ mod test {
         let unique_count = u8::encode(&input, &mut rle_vals, &mut rle_idxs);
 
         let mut decoded = [0u8; 1024];
-        u8::decode(&rle_vals[..unique_count], &rle_idxs, &mut decoded);
+        // SAFETY: `encode` only writes indices below the returned `unique_count`.
+        unsafe { u8::decode(&rle_vals[..unique_count], &rle_idxs, &mut decoded) };
         assert_eq!(input, decoded);
     }
 }

--- a/src/rle.rs
+++ b/src/rle.rs
@@ -14,7 +14,7 @@ pub trait RLE: Sized {
     ///
     /// Implementations perform unchecked buffer accesses that rely on these bounds; they are
     /// checked only with `debug_assert` (i.e., not checked on release builds).
-    unsafe fn encode(
+    unsafe fn encode_unchecked(
         input: &[Self; 1024],
         rle_vals: &mut [Self; 1024],
         rle_idxs: &mut [u16; 1024],
@@ -30,14 +30,17 @@ pub trait RLE: Sized {
     ///   `rle_vals.len()`.
     ///
     /// This is checked only with `debug_assert` (i.e., not checked on release builds).
-    unsafe fn decode<I>(rle_vals: &[Self], rle_idxs: &[I; 1024], output: &mut [Self; 1024])
-    where
+    unsafe fn decode_unchecked<I>(
+        rle_vals: &[Self],
+        rle_idxs: &[I; 1024],
+        output: &mut [Self; 1024],
+    ) where
         I: Copy + Into<usize>;
 }
 
 impl<T: PartialEq + Copy> RLE for T {
     #[inline(never)]
-    unsafe fn encode(
+    unsafe fn encode_unchecked(
         input: &[Self; 1024],
         rle_vals: &mut [Self; 1024],
         rle_idxs: &mut [u16; 1024],
@@ -68,8 +71,11 @@ impl<T: PartialEq + Copy> RLE for T {
     }
 
     #[inline(never)]
-    unsafe fn decode<I>(rle_vals: &[Self], rle_idxs: &[I; 1024], output: &mut [Self; 1024])
-    where
+    unsafe fn decode_unchecked<I>(
+        rle_vals: &[Self],
+        rle_idxs: &[I; 1024],
+        output: &mut [Self; 1024],
+    ) where
         I: Copy + Into<usize>,
     {
         for (idx, output) in rle_idxs.iter().zip(output.iter_mut()) {
@@ -91,7 +97,7 @@ mod test {
         let mut rle_idxs = [0u16; 1024];
 
         // SAFETY: all arguments are 1024-element arrays.
-        let unique_count = unsafe { u32::encode(&input, &mut rle_vals, &mut rle_idxs) };
+        let unique_count = unsafe { u32::encode_unchecked(&input, &mut rle_vals, &mut rle_idxs) };
 
         assert_eq!(unique_count, 11);
     }
@@ -103,7 +109,7 @@ mod test {
         let mut rle_idxs = [0u16; 1024];
 
         // SAFETY: all arguments are 1024-element arrays.
-        let unique_count = unsafe { u32::encode(&input, &mut rle_vals, &mut rle_idxs) };
+        let unique_count = unsafe { u32::encode_unchecked(&input, &mut rle_vals, &mut rle_idxs) };
 
         // Check that RLE values are 1, 2, 3, ..., 11
         for i in 0..unique_count {
@@ -118,7 +124,7 @@ mod test {
         let mut rle_idxs = [0u16; 1024];
 
         // SAFETY: all arguments are 1024-element arrays.
-        unsafe { u32::encode(&input, &mut rle_vals, &mut rle_idxs) };
+        unsafe { u32::encode_unchecked(&input, &mut rle_vals, &mut rle_idxs) };
 
         for i in 0..100 {
             assert_eq!(rle_idxs[i], 0);
@@ -140,7 +146,7 @@ mod test {
         let mut rle_idxs = [0u16; 1024];
 
         // SAFETY: all arguments are 1024-element arrays.
-        let unique_count = unsafe { u16::encode(&input, &mut rle_vals, &mut rle_idxs) };
+        let unique_count = unsafe { u16::encode_unchecked(&input, &mut rle_vals, &mut rle_idxs) };
 
         assert_eq!(unique_count, 1);
         assert_eq!(rle_vals[0], 42);
@@ -158,7 +164,7 @@ mod test {
         let mut rle_idxs = [0u16; 1024];
 
         // SAFETY: all arguments are 1024-element arrays.
-        let unique_count = unsafe { u8::encode(&input, &mut rle_vals, &mut rle_idxs) };
+        let unique_count = unsafe { u8::encode_unchecked(&input, &mut rle_vals, &mut rle_idxs) };
 
         // RLE creates a new dictionary entry every time the value changes,
         // not when we encounter a new unique value.
@@ -172,11 +178,11 @@ mod test {
         let mut rle_vals = [0u8; 1024];
         let mut rle_idxs = [0u16; 1024];
         // SAFETY: all arguments are 1024-element arrays.
-        let unique_count = unsafe { u8::encode(&input, &mut rle_vals, &mut rle_idxs) };
+        let unique_count = unsafe { u8::encode_unchecked(&input, &mut rle_vals, &mut rle_idxs) };
 
         let mut decoded = [0u8; 1024];
-        // SAFETY: `encode` only writes indices below the returned `unique_count`.
-        unsafe { u8::decode(&rle_vals[..unique_count], &rle_idxs, &mut decoded) };
+        // SAFETY: `encode_unchecked` only writes indices below the returned `unique_count`.
+        unsafe { u8::decode_unchecked(&rle_vals[..unique_count], &rle_idxs, &mut decoded) };
         assert_eq!(input, decoded);
     }
 }


### PR DESCRIPTION
## Summary
Convert the `RLE::{encode/decode}` method to an unsafe function to reflect its actual safety requirements. The method performs unchecked indexing into the `rle_vals` slice, which requires callers to guarantee that all indices in `rle_idxs` are valid.
