### PR TITLE
Pin bench stack buffers to 128-byte alignment

### DIFF
--- a/benches/bitpacking.rs
+++ b/benches/bitpacking.rs
@@ -7,6 +7,8 @@ use std::hint::black_box;
 
 mod shared;
 
+use shared::Aligned;
+
 fn main() {
     divan::main();
 }
@@ -31,12 +33,12 @@ fn pack_16_to_3_heap(bencher: Bencher) {
 fn pack_16_to_3_stack(bencher: Bencher) {
     const WIDTH: usize = 3;
     const B: usize = 1024 * WIDTH / u16::T;
-    let values = [3u16; 1024];
-    let mut packed = [0; 128 * WIDTH / size_of::<u16>()];
+    let values = Aligned([3u16; 1024]);
+    let mut packed = Aligned([0; 128 * WIDTH / size_of::<u16>()]);
 
     bencher.bench_local(|| {
-        BitPacking::pack::<WIDTH, B>(black_box(&values), &mut packed);
-        black_box(&packed);
+        BitPacking::pack::<WIDTH, B>(black_box(&values.0), &mut packed.0);
+        black_box(&packed.0);
     });
 }
 
@@ -44,15 +46,15 @@ fn pack_16_to_3_stack(bencher: Bencher) {
 fn unpack_16_from_3_stack(bencher: Bencher) {
     const WIDTH: usize = 3;
     const B: usize = 1024 * WIDTH / u16::T;
-    let values = [3u16; 1024];
-    let mut packed = [0; 128 * WIDTH / size_of::<u16>()];
-    BitPacking::pack::<WIDTH, B>(&values, &mut packed);
+    let values = Aligned([3u16; 1024]);
+    let mut packed = Aligned([0; 128 * WIDTH / size_of::<u16>()]);
+    BitPacking::pack::<WIDTH, B>(&values.0, &mut packed.0);
 
-    let mut unpacked = [0u16; 1024];
+    let mut unpacked = Aligned([0u16; 1024]);
 
     bencher.bench_local(|| {
-        BitPacking::unpack::<WIDTH, B>(black_box(&packed), &mut unpacked);
-        black_box(&unpacked);
+        BitPacking::unpack::<WIDTH, B>(black_box(&packed.0), &mut unpacked.0);
+        black_box(&unpacked.0);
     });
 }
 
@@ -60,15 +62,15 @@ fn unpack_16_from_3_stack(bencher: Bencher) {
 fn unchecked_unpack_16_from_3_stack(bencher: Bencher) {
     const WIDTH: usize = 3;
     const B: usize = 1024 * WIDTH / u16::T;
-    let values = [3u16; 1024];
-    let mut packed = [0; 128 * WIDTH / size_of::<u16>()];
-    BitPacking::pack::<WIDTH, B>(&values, &mut packed);
+    let values = Aligned([3u16; 1024]);
+    let mut packed = Aligned([0; 128 * WIDTH / size_of::<u16>()]);
+    BitPacking::pack::<WIDTH, B>(&values.0, &mut packed.0);
 
-    let mut unpacked = [0u16; 1024];
+    let mut unpacked = Aligned([0u16; 1024]);
 
     bencher.bench_local(|| {
-        unsafe { BitPacking::unchecked_unpack(WIDTH, black_box(&packed), &mut unpacked) };
-        black_box(&unpacked);
+        unsafe { BitPacking::unchecked_unpack(WIDTH, black_box(&packed.0), &mut unpacked.0) };
+        black_box(&unpacked.0);
     });
 }
 

--- a/benches/bitpacking_cmp.rs
+++ b/benches/bitpacking_cmp.rs
@@ -1,10 +1,13 @@
 #![allow(unexpected_cfgs)]
 
+mod shared;
+
 fn main() {
     divan::main();
 }
 
 mod bench {
+    use crate::shared::Aligned;
     use divan::Bencher;
     use fastlanes::{
         untranspose_bits, BitPacking, BitPackingCompare, FastLanes, FastLanesComparable,
@@ -34,25 +37,25 @@ mod bench {
             return;
         }
         let value = T::from_usize(1).expect("");
-        let values = [T::from_usize(2).expect(""); 1024];
+        let values = Aligned([T::from_usize(2).expect(""); 1024]);
         let mut packed = vec![T::zero(); 128 * width / size_of::<T>()];
-        unsafe { T::unchecked_pack(width, &values, &mut packed) };
+        unsafe { T::unchecked_pack(width, &values.0, &mut packed) };
 
-        let mut transposed = [0u64; 16];
-        let mut logical = [0u64; 16];
+        let mut transposed = Aligned([0u64; 16]);
+        let mut logical = Aligned([0u64; 16]);
 
         bencher.bench_local(|| {
             unsafe {
                 T::unchecked_unpack_cmp(
                     black_box(width),
                     black_box(&packed),
-                    &mut transposed,
+                    &mut transposed.0,
                     |a, b| a == b,
                     black_box(value),
                 );
             }
-            untranspose_bits::<T>(black_box(&transposed), &mut logical);
-            black_box(&logical);
+            untranspose_bits::<T>(black_box(&transposed.0), &mut logical.0);
+            black_box(&logical.0);
         });
     }
 }

--- a/benches/delta.rs
+++ b/benches/delta.rs
@@ -7,6 +7,8 @@ use fastlanes::{BitPacking, Delta, FastLanes, Transpose};
 
 mod shared;
 
+use shared::Aligned;
+
 fn main() {
     divan::main();
 }
@@ -17,23 +19,28 @@ fn delta_u16_fused(bencher: Bencher) {
     const B: usize = 1024 * W / <u16 as FastLanes>::T;
     const LANES: usize = u16::LANES;
 
-    let mut values: [u16; 1024] = [0; 1024];
+    let mut values = Aligned([0u16; 1024]);
     for i in 0..1024 {
-        values[i] = (i / 8) as u16;
+        values.0[i] = (i / 8) as u16;
     }
 
-    let mut transposed = [0; 1024];
-    Transpose::transpose(&values, &mut transposed);
+    let mut transposed = Aligned([0; 1024]);
+    Transpose::transpose(&values.0, &mut transposed.0);
 
-    let mut deltas = [0; 1024];
-    Delta::delta(&transposed, &[0; 64], &mut deltas);
+    let bases = Aligned([0; 64]);
+    let mut deltas = Aligned([0; 1024]);
+    Delta::delta(&transposed.0, &bases.0, &mut deltas.0);
 
-    let mut packed = [0; 128 * W / size_of::<u16>()];
-    BitPacking::pack::<W, B>(&deltas, &mut packed);
+    let mut packed = Aligned([0; 128 * W / size_of::<u16>()]);
+    BitPacking::pack::<W, B>(&deltas.0, &mut packed.0);
 
-    with_counter!(bencher, values.len() * std::mem::size_of::<u16>()).bench_local(|| {
-        let mut unpacked = [0; 1024];
-        Delta::undelta_pack::<LANES, W, B>(black_box(&packed), black_box(&[0; 64]), &mut unpacked);
+    with_counter!(bencher, values.0.len() * std::mem::size_of::<u16>()).bench_local(|| {
+        let mut unpacked = Aligned([0; 1024]);
+        Delta::undelta_pack::<LANES, W, B>(
+            black_box(&packed.0),
+            black_box(&bases.0),
+            &mut unpacked.0,
+        );
         unpacked
     });
 }
@@ -43,25 +50,26 @@ fn delta_u16_unfused(bencher: Bencher) {
     const W: usize = 9;
     const B: usize = 1024 * W / <u16 as FastLanes>::T;
 
-    let mut values: [u16; 1024] = [0; 1024];
+    let mut values = Aligned([0u16; 1024]);
     for i in 0..1024 {
-        values[i] = (i / 8) as u16;
+        values.0[i] = (i / 8) as u16;
     }
 
-    let mut transposed = [0; 1024];
-    Transpose::transpose(&values, &mut transposed);
+    let mut transposed = Aligned([0; 1024]);
+    Transpose::transpose(&values.0, &mut transposed.0);
 
-    let mut deltas = [0; 1024];
-    Delta::delta(&transposed, &[0; 64], &mut deltas);
+    let bases = Aligned([0; 64]);
+    let mut deltas = Aligned([0; 1024]);
+    Delta::delta(&transposed.0, &bases.0, &mut deltas.0);
 
-    let mut packed = [0; 128 * W / size_of::<u16>()];
-    BitPacking::pack::<W, B>(&deltas, &mut packed);
+    let mut packed = Aligned([0; 128 * W / size_of::<u16>()]);
+    BitPacking::pack::<W, B>(&deltas.0, &mut packed.0);
 
-    with_counter!(bencher, values.len() * std::mem::size_of::<u16>()).bench_local(|| {
-        let mut unpacked = [0; 1024];
-        BitPacking::unpack::<W, B>(black_box(&packed), &mut unpacked);
-        let mut undelta = [0; 1024];
-        Delta::undelta(black_box(&unpacked), black_box(&[0; 64]), &mut undelta);
+    with_counter!(bencher, values.0.len() * std::mem::size_of::<u16>()).bench_local(|| {
+        let mut unpacked = Aligned([0; 1024]);
+        BitPacking::unpack::<W, B>(black_box(&packed.0), &mut unpacked.0);
+        let mut undelta = Aligned([0; 1024]);
+        Delta::undelta(black_box(&unpacked.0), black_box(&bases.0), &mut undelta.0);
         undelta
     });
 }

--- a/benches/ffor.rs
+++ b/benches/ffor.rs
@@ -7,6 +7,8 @@ use std::hint::black_box;
 
 mod shared;
 
+use shared::Aligned;
+
 fn main() {
     divan::main();
 }
@@ -33,13 +35,13 @@ fn for_pack_16_to_3_heap(bencher: Bencher) {
 fn for_pack_16_to_3_stack(bencher: Bencher) {
     const WIDTH: usize = 3;
     const B: usize = 1024 * WIDTH / u16::T;
-    let values = [13u16; 1024];
-    let mut packed = [0; 128 * WIDTH / size_of::<u16>()];
+    let values = Aligned([13u16; 1024]);
+    let mut packed = Aligned([0; 128 * WIDTH / size_of::<u16>()]);
     let reference = 10u16;
 
     bencher.bench_local(|| {
-        FoR::for_pack::<WIDTH, B>(black_box(&values), reference, &mut packed);
-        black_box(&packed);
+        FoR::for_pack::<WIDTH, B>(black_box(&values.0), reference, &mut packed.0);
+        black_box(&packed.0);
     });
 }
 
@@ -47,16 +49,16 @@ fn for_pack_16_to_3_stack(bencher: Bencher) {
 fn unfor_pack_16_from_3_stack(bencher: Bencher) {
     const WIDTH: usize = 3;
     const B: usize = 1024 * WIDTH / u16::T;
-    let values = [13u16; 1024];
-    let mut packed = [0; 128 * WIDTH / size_of::<u16>()];
+    let values = Aligned([13u16; 1024]);
+    let mut packed = Aligned([0; 128 * WIDTH / size_of::<u16>()]);
     let reference = 10u16;
-    FoR::for_pack::<WIDTH, B>(&values, reference, &mut packed);
+    FoR::for_pack::<WIDTH, B>(&values.0, reference, &mut packed.0);
 
-    let mut unpacked = [0u16; 1024];
+    let mut unpacked = Aligned([0u16; 1024]);
 
     bencher.bench_local(|| {
-        FoR::unfor_pack::<WIDTH, B>(black_box(&packed), reference, &mut unpacked);
-        black_box(&unpacked);
+        FoR::unfor_pack::<WIDTH, B>(black_box(&packed.0), reference, &mut unpacked.0);
+        black_box(&unpacked.0);
     });
 }
 
@@ -64,16 +66,18 @@ fn unfor_pack_16_from_3_stack(bencher: Bencher) {
 fn unchecked_unfor_pack_16_from_3_stack(bencher: Bencher) {
     const WIDTH: usize = 3;
     const B: usize = 1024 * WIDTH / u16::T;
-    let values = [13u16; 1024];
-    let mut packed = [0; 128 * WIDTH / size_of::<u16>()];
+    let values = Aligned([13u16; 1024]);
+    let mut packed = Aligned([0; 128 * WIDTH / size_of::<u16>()]);
     let reference = 10u16;
-    FoR::for_pack::<WIDTH, B>(&values, reference, &mut packed);
+    FoR::for_pack::<WIDTH, B>(&values.0, reference, &mut packed.0);
 
-    let mut unpacked = [0u16; 1024];
+    let mut unpacked = Aligned([0u16; 1024]);
 
     bencher.bench_local(|| {
-        unsafe { FoR::unchecked_unfor_pack(WIDTH, black_box(&packed), reference, &mut unpacked) };
-        black_box(&unpacked);
+        unsafe {
+            FoR::unchecked_unfor_pack(WIDTH, black_box(&packed.0), reference, &mut unpacked.0);
+        };
+        black_box(&unpacked.0);
     });
 }
 
@@ -178,21 +182,21 @@ fn throughput_decompress_unchecked(bencher: Bencher) {
 fn unpack_then_add_reference_16_from_3_stack(bencher: Bencher) {
     const WIDTH: usize = 3;
     const B: usize = 1024 * WIDTH / u16::T;
-    let values = [13u16; 1024];
-    let mut packed = [0; 128 * WIDTH / size_of::<u16>()];
+    let values = Aligned([13u16; 1024]);
+    let mut packed = Aligned([0; 128 * WIDTH / size_of::<u16>()]);
     let reference = 10u16;
-    FoR::for_pack::<WIDTH, B>(&values, reference, &mut packed);
+    FoR::for_pack::<WIDTH, B>(&values.0, reference, &mut packed.0);
 
-    let mut unpacked = [0u16; 1024];
+    let mut unpacked = Aligned([0u16; 1024]);
 
     bencher.bench_local(|| {
         // First, unpack using bitpacking kernel
-        BitPacking::unpack::<WIDTH, B>(black_box(&packed), &mut unpacked);
+        BitPacking::unpack::<WIDTH, B>(black_box(&packed.0), &mut unpacked.0);
         // Then, apply reference values in a separate loop
         for i in 0..1024 {
-            unpacked[i] = unpacked[i].wrapping_add(reference);
+            unpacked.0[i] = unpacked.0[i].wrapping_add(reference);
         }
-        black_box(&unpacked);
+        black_box(&unpacked.0);
     });
 }
 
@@ -200,21 +204,21 @@ fn unpack_then_add_reference_16_from_3_stack(bencher: Bencher) {
 fn unchecked_unpack_then_add_reference_16_from_3_stack(bencher: Bencher) {
     const WIDTH: usize = 3;
     const B: usize = 1024 * WIDTH / u16::T;
-    let values = [13u16; 1024];
-    let mut packed = [0; 128 * WIDTH / size_of::<u16>()];
+    let values = Aligned([13u16; 1024]);
+    let mut packed = Aligned([0; 128 * WIDTH / size_of::<u16>()]);
     let reference = 10u16;
-    FoR::for_pack::<WIDTH, B>(&values, reference, &mut packed);
+    FoR::for_pack::<WIDTH, B>(&values.0, reference, &mut packed.0);
 
-    let mut unpacked = [0u16; 1024];
+    let mut unpacked = Aligned([0u16; 1024]);
 
     bencher.bench_local(|| {
         // First, unpack using unchecked bitpacking kernel
-        unsafe { BitPacking::unchecked_unpack(WIDTH, black_box(&packed), &mut unpacked) };
+        unsafe { BitPacking::unchecked_unpack(WIDTH, black_box(&packed.0), &mut unpacked.0) };
         // Then, apply reference values in a separate loop
         for i in 0..1024 {
-            unpacked[i] = unpacked[i].wrapping_add(reference);
+            unpacked.0[i] = unpacked.0[i].wrapping_add(reference);
         }
-        black_box(&unpacked);
+        black_box(&unpacked.0);
     });
 }
 

--- a/benches/rle.rs
+++ b/benches/rle.rs
@@ -5,38 +5,44 @@ use std::hint::black_box;
 
 mod shared;
 
+use shared::Aligned;
+
 fn main() {
     divan::main();
 }
 
 #[divan::bench]
 fn rle_encode_u32(bencher: Bencher) {
-    let input: [u32; 1024] = std::array::from_fn(|i| (i / 100 + 1) as u32);
-    let mut rle_vals = [0u32; 1024];
-    let mut rle_idxs = [0u16; 1024];
+    let input = Aligned(std::array::from_fn::<u32, 1024, _>(|i| {
+        (i / 100 + 1) as u32
+    }));
+    let mut rle_vals = Aligned([0u32; 1024]);
+    let mut rle_idxs = Aligned([0u16; 1024]);
 
     bencher.bench_local(|| {
-        let unique_count = u32::encode(black_box(&input), &mut rle_vals, &mut rle_idxs);
+        let unique_count = u32::encode(black_box(&input.0), &mut rle_vals.0, &mut rle_idxs.0);
         black_box(unique_count);
     });
 }
 
 #[divan::bench]
 fn rle_decode_u32(bencher: Bencher) {
-    let input: [u32; 1024] = std::array::from_fn(|i| (i / 100 + 1) as u32);
-    let mut rle_vals = [0u32; 1024];
-    let mut rle_idxs = [0u16; 1024];
-    let unique_count = u32::encode(&input, &mut rle_vals, &mut rle_idxs);
+    let input = Aligned(std::array::from_fn::<u32, 1024, _>(|i| {
+        (i / 100 + 1) as u32
+    }));
+    let mut rle_vals = Aligned([0u32; 1024]);
+    let mut rle_idxs = Aligned([0u16; 1024]);
+    let unique_count = u32::encode(&input.0, &mut rle_vals.0, &mut rle_idxs.0);
 
-    let mut output = [0u32; 1024];
+    let mut output = Aligned([0u32; 1024]);
 
     bencher.bench_local(|| {
         u32::decode(
-            black_box(&rle_vals[..unique_count]),
-            black_box(&rle_idxs),
-            &mut output,
+            black_box(&rle_vals.0[..unique_count]),
+            black_box(&rle_idxs.0),
+            &mut output.0,
         );
-        black_box(&output);
+        black_box(&output.0);
     });
 }
 
@@ -48,13 +54,14 @@ fn rle_throughput_encode_32(bencher: Bencher) {
     let input_data: Vec<u32> = (0..N).map(|i| (i / 100) as u32).collect();
 
     with_counter!(bencher, input_data.len() * std::mem::size_of::<u32>()).bench_local(|| {
-        let mut rle_vals = [0u32; 1024];
-        let mut rle_idxs = [0u16; 1024];
+        let mut rle_vals = Aligned([0u32; 1024]);
+        let mut rle_idxs = Aligned([0u16; 1024]);
         for batch in 0..NUM_BATCHES {
             let batch_start = batch * 1024;
             let input_batch = array_ref![input_data, batch_start, 1024];
 
-            let unique_count = u32::encode(black_box(input_batch), &mut rle_vals, &mut rle_idxs);
+            let unique_count =
+                u32::encode(black_box(input_batch), &mut rle_vals.0, &mut rle_idxs.0);
             black_box(unique_count);
         }
     });
@@ -73,21 +80,21 @@ fn rle_throughput_decode_32(bencher: Bencher) {
         let batch_start = batch * 1024;
         let input_batch: [u32; 1024] = std::array::from_fn(|i| input_data[batch_start + i]);
 
-        let mut rle_vals = [0u32; 1024];
-        let mut rle_idxs = [0u16; 1024];
-        let unique_count = u32::encode(&input_batch, &mut rle_vals, &mut rle_idxs);
+        let mut rle_vals = Aligned([0u32; 1024]);
+        let mut rle_idxs = Aligned([0u16; 1024]);
+        let unique_count = u32::encode(&input_batch, &mut rle_vals.0, &mut rle_idxs.0);
         encoded_batches.push((rle_vals, rle_idxs, unique_count));
     }
 
     with_counter!(bencher, input_data.len() * std::mem::size_of::<u32>()).bench_local(|| {
-        let mut output = [0u32; 1024];
+        let mut output = Aligned([0u32; 1024]);
         for (rle_vals, rle_idxs, unique_count) in &encoded_batches {
             u32::decode(
-                black_box(&rle_vals[..*unique_count]),
-                black_box(rle_idxs),
-                &mut output,
+                black_box(&rle_vals.0[..*unique_count]),
+                black_box(&rle_idxs.0),
+                &mut output.0,
             );
-            black_box(&output);
+            black_box(&output.0);
         }
     });
 }

--- a/benches/shared/mod.rs
+++ b/benches/shared/mod.rs
@@ -1,3 +1,12 @@
+/// A `T` pinned to 128-byte alignment, one full 1024-bit `FastLanes` vector.
+///
+/// Bench buffers declared as plain stack arrays inherit whatever alignment the
+/// enclosing frame happens to give them, so unrelated code changes can move
+/// them relative to cache-line and SIMD-lane boundaries and show up as phantom
+/// performance changes. Wrapping the buffer pins its alignment across builds.
+#[repr(C, align(128))]
+pub struct Aligned<T>(pub T);
+
 // Helper macro to conditionally add counter based on codspeed cfg
 #[macro_export]
 macro_rules! with_counter {

--- a/benches/transpose.rs
+++ b/benches/transpose.rs
@@ -3,21 +3,25 @@ use std::hint::black_box;
 
 use fastlanes::Transpose;
 
+mod shared;
+
+use shared::Aligned;
+
 fn main() {
     divan::main();
 }
 
 #[divan::bench]
 fn transpose_u16(bencher: Bencher) {
-    let mut values: [u16; 1024] = [0; 1024];
+    let mut values = Aligned([0u16; 1024]);
     for i in 0..1024 {
-        values[i] = (i % u16::MAX as usize) as u16;
+        values.0[i] = (i % u16::MAX as usize) as u16;
     }
 
-    let mut transposed = [0; 1024];
+    let mut transposed = Aligned([0; 1024]);
 
     bencher.bench_local(|| {
-        Transpose::transpose(black_box(&values), &mut transposed);
-        black_box(&transposed);
+        Transpose::transpose(black_box(&values.0), &mut transposed.0);
+        black_box(&transposed.0);
     });
 }


### PR DESCRIPTION
## Problem

The `*_stack` benchmarks declare their buffers as plain local arrays (e.g. `let mut packed = [0u16; 192];`), which only get the element type's natural alignment. The stack frame layout — and therefore the buffers' position relative to cache-line and SIMD-lane boundaries — shifts whenever unrelated code changes. On CodSpeed this shows up as phantom ±30% "performance changes" on `for_pack_16_to_3_stack`, `unfor_pack_16_from_3_stack`, and `unchecked_unfor_pack_16_from_3_stack` even when the kernels are untouched.

## Fix

- Add an `Aligned<T>` wrapper in `benches/shared/mod.rs` with `#[repr(C, align(128))]` — 128 bytes is one full 1024-bit FastLanes virtual vector, covering every real cache-line and SIMD width.
- Wrap every stack array that feeds a benchmarked kernel (`bitpacking`, `ffor`, `delta`, `rle`, `transpose`, `bitpacking_cmp` benches), including arrays allocated inside `bench_local` closures and the delta `bases` arrays, so buffer placement is identical in every build.

Heap (`vec[...]`) buffers are left as-is; allocator placement is a separate, much smaller effect and those benches were not affected.

Note: the first CodSpeed run of this PR will itself report a one-off shift on the `_stack` benchmarks (alignment moves from "wherever the frame put it" to pinned). After this baseline lands, they should stay flat until a kernel actually changes.

## Checks

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features` (crate denies warnings + pedantic)
- All six modified bench binaries run in release mode with sane results

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UUfJpFLoBrg8uF2pFuUHv

---
_Generated by [Claude Code](https://claude.ai/code/session_014UUfJpFLoBrg8uF2pFuUHv)_