### PR TITLE
chore: Move to 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/spiraldb/fastlanes"
 repository = "https://github.com/spiraldb/fastlanes"
 authors = ["SpiralDB <hello@spiraldb.com>"]
 keywords = ["fastlanes", "compression", "codec", "encoding", "lightweight"]
-edition = "2021"
+edition = "2024"
 rust-version = "1.91"
 exclude = [".github/*", "renovate.json"]
 

--- a/benches/bit_transpose.rs
+++ b/benches/bit_transpose.rs
@@ -2,8 +2,8 @@ use std::hint::black_box;
 
 use arrayref::array_mut_ref;
 use arrayref::array_ref;
-use divan::counter::BytesCount;
 use divan::Bencher;
+use divan::counter::BytesCount;
 use fastlanes::FastLanes;
 
 fn main() {
@@ -61,9 +61,9 @@ fn dispatch_untranspose<T: FastLanes>(bencher: Bencher) {
 
 #[cfg(target_arch = "x86_64")]
 mod x86 {
-    use super::{bench_blocks, Bencher};
-    use fastlanes::x86;
+    use super::{Bencher, bench_blocks};
     use fastlanes::FastLanes;
+    use fastlanes::x86;
 
     #[divan::bench]
     fn bmi2_transpose(bencher: Bencher) {
@@ -108,9 +108,9 @@ mod x86 {
 
 #[cfg(target_arch = "aarch64")]
 mod aarch64 {
-    use super::{bench_blocks, Bencher};
-    use fastlanes::aarch64;
+    use super::{Bencher, bench_blocks};
     use fastlanes::FastLanes;
+    use fastlanes::aarch64;
 
     #[divan::bench]
     fn neon_transpose(bencher: Bencher) {

--- a/benches/bitpacking_cmp.rs
+++ b/benches/bitpacking_cmp.rs
@@ -7,7 +7,7 @@ fn main() {
 mod bench {
     use divan::Bencher;
     use fastlanes::{
-        untranspose_bits, BitPacking, BitPackingCompare, FastLanes, FastLanesComparable,
+        BitPacking, BitPackingCompare, FastLanes, FastLanesComparable, untranspose_bits,
     };
     use num_traits::FromPrimitive;
     use std::hint::black_box;

--- a/src/bit_transpose/aarch64.rs
+++ b/src/bit_transpose/aarch64.rs
@@ -2,27 +2,27 @@
 
 use core::arch::aarch64::uint64x2_t;
 use core::arch::aarch64::vandq_u64;
-use core::arch::aarch64::vdupq_n_u64;
 use core::arch::aarch64::vdupq_n_u8;
+use core::arch::aarch64::vdupq_n_u64;
 use core::arch::aarch64::veorq_u64;
 use core::arch::aarch64::vld1q_u8;
 use core::arch::aarch64::vld1q_u8_x4;
 use core::arch::aarch64::vorrq_u8;
 use core::arch::aarch64::vqtbl4q_u8;
-use core::arch::aarch64::vreinterpretq_u64_u8;
 use core::arch::aarch64::vreinterpretq_u8_u64;
+use core::arch::aarch64::vreinterpretq_u64_u8;
 use core::arch::aarch64::vshlq_n_u64;
 use core::arch::aarch64::vshrq_n_u64;
 use core::arch::aarch64::vst1q_u8;
 use core::arch::aarch64::vsubq_u8;
 
-use crate::bit_transpose::as_byte_array;
-use crate::bit_transpose::as_byte_array_mut;
-use crate::bit_transpose::group_perm::group_tables;
+use crate::FastLanes;
 use crate::bit_transpose::TRANSPOSE_2X2;
 use crate::bit_transpose::TRANSPOSE_4X4;
 use crate::bit_transpose::TRANSPOSE_8X8;
-use crate::FastLanes;
+use crate::bit_transpose::as_byte_array;
+use crate::bit_transpose::as_byte_array_mut;
+use crate::bit_transpose::group_perm::group_tables;
 
 /// Gather indices for the first half from input[0..64] (low 4 bytes of each group).
 static GATHER_FIRST_LO: [[u8; 16]; 4] = [

--- a/src/bit_transpose/scalar.rs
+++ b/src/bit_transpose/scalar.rs
@@ -6,15 +6,15 @@
 //! kernels do eight groups at once in a single register; the scalar code does them one
 //! at a time and relies on the compiler to unroll the fixed-length loops.
 
-use crate::bit_transpose::as_byte_array;
-use crate::bit_transpose::as_byte_array_mut;
+use crate::FL_ORDER;
+use crate::FastLanes;
 use crate::bit_transpose::BASE_PATTERN_FIRST;
 use crate::bit_transpose::BASE_PATTERN_SECOND;
 use crate::bit_transpose::TRANSPOSE_2X2;
 use crate::bit_transpose::TRANSPOSE_4X4;
 use crate::bit_transpose::TRANSPOSE_8X8;
-use crate::FastLanes;
-use crate::FL_ORDER;
+use crate::bit_transpose::as_byte_array;
+use crate::bit_transpose::as_byte_array_mut;
 
 /// The two halves of the `FastLanes` byte-group ordering.
 const HALVES: [[usize; 8]; 2] = [BASE_PATTERN_FIRST, BASE_PATTERN_SECOND];

--- a/src/bit_transpose/x86.rs
+++ b/src/bit_transpose/x86.rs
@@ -14,16 +14,16 @@ use core::arch::x86_64::_mm512_xor_si512;
 use core::arch::x86_64::_pdep_u64;
 use core::arch::x86_64::_pext_u64;
 
-use crate::bit_transpose::as_byte_array;
-use crate::bit_transpose::as_byte_array_mut;
-use crate::bit_transpose::group_perm::group_tables;
+use crate::FL_ORDER;
+use crate::FastLanes;
 use crate::bit_transpose::BASE_PATTERN_FIRST;
 use crate::bit_transpose::BASE_PATTERN_SECOND;
 use crate::bit_transpose::TRANSPOSE_2X2;
 use crate::bit_transpose::TRANSPOSE_4X4;
 use crate::bit_transpose::TRANSPOSE_8X8;
-use crate::FastLanes;
-use crate::FL_ORDER;
+use crate::bit_transpose::as_byte_array;
+use crate::bit_transpose::as_byte_array_mut;
+use crate::bit_transpose::group_perm::group_tables;
 
 /// Check if BMI2 is available (requires the `std` feature for runtime detection).
 #[cfg(feature = "std")]

--- a/src/bitpacking.rs
+++ b/src/bitpacking.rs
@@ -2,7 +2,7 @@ use const_for::const_for;
 use core::mem::size_of;
 use paste::paste;
 
-use crate::{pack, seq_t, supported_bit_width, unpack, FastLanes, FL_ORDER};
+use crate::{FL_ORDER, FastLanes, pack, seq_t, supported_bit_width, unpack};
 
 /// `BitPack` into a compile-time known bit-width.
 pub trait BitPacking: FastLanes {

--- a/src/bitpacking_cmp.rs
+++ b/src/bitpacking_cmp.rs
@@ -1,6 +1,6 @@
 use crate::seq_t;
 use crate::unpack;
-use crate::{supported_bit_width, FastLanes, FastLanesComparable};
+use crate::{FastLanes, FastLanesComparable, supported_bit_width};
 use paste::paste;
 
 pub trait BitPackingCompare: FastLanes {
@@ -141,7 +141,7 @@ impl_packing_compare!(u64);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{untranspose_bits, BitPacking};
+    use crate::{BitPacking, untranspose_bits};
     use alloc::vec::Vec;
     use core::array;
 

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -1,6 +1,6 @@
 #![allow(unused_assignments)]
 
-use crate::{iterate, supported_bit_width, unpack, BitPacking, FastLanes};
+use crate::{BitPacking, FastLanes, iterate, supported_bit_width, unpack};
 
 pub trait Delta: BitPacking {
     fn delta<const LANES: usize>(

--- a/src/ffor.rs
+++ b/src/ffor.rs
@@ -1,4 +1,4 @@
-use crate::{pack, seq_t, supported_bit_width, unpack, BitPacking, FastLanes};
+use crate::{BitPacking, FastLanes, pack, seq_t, supported_bit_width, unpack};
 use paste::paste;
 
 pub trait FoR: BitPacking {

--- a/src/transpose.rs
+++ b/src/transpose.rs
@@ -1,4 +1,4 @@
-use crate::{FastLanes, FL_ORDER};
+use crate::{FL_ORDER, FastLanes};
 use seq_macro::seq;
 
 pub trait Transpose: FastLanes {


### PR DESCRIPTION
At this point, why not? Just more consistent with the other projects we have, and our msrv is already pretty high.