### PR TITLE
Replace round-trip tests with hegel-based property testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,19 @@ jobs:
       - uses: ./.github/actions/setup-rust
 
       - name: Rust Build
-        run: cargo build --all-features --all-targets
+        run: |
+            cargo build --all-features --all-targets
+            cargo build --all-targets
       - name: Rust Lint - Format
         run: cargo fmt --all --check
       - name: Rust Lint - Clippy
-        run: cargo clippy --all-features --all-targets
+        run: |
+            cargo clippy --all-features --all-targets
+            cargo clippy --all-targets
       - name: Rust Test
-        run: cargo test --workspace --all-features
+        run: |
+            cargo test --workspace --all-features
+            cargo test --workspace
 
   msrv:
     name: MSRV

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,7 @@ target/
 .DS_Store
 
 # Added by cargo
-
 /target
+
+# For the hegel property testing crate
+.hegel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,10 +18,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
 
 [[package]]
 name = "anyhow"
@@ -51,6 +101,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "cbindgen"
+version = "0.29.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ecb53484c9c167ba674026b656d8a27d7657a58e6066aa902bfb1a4aa00ae20"
+dependencies = [
+ "clap",
+ "heck",
+ "indexmap",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.119",
+ "tempfile",
+ "toml",
+]
+
+[[package]]
 name = "cc"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +142,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,8 +167,10 @@ version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
  "terminal_size",
 ]
 
@@ -159,6 +241,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "colored"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +266,43 @@ name = "const_for"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "988d3bd6bf67b6d7ae2b519c55296fa57411c27c312575e47b2975f8d1d8590b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "dashu-base"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993b95dc1b248e3f5747dcb017a41d6e75853a2e5ee4504f7d537c5b8dffdae4"
+
+[[package]]
+name = "dashu-int"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49c05a0d5cb0b39fcc87c46432fdac24b90dce239857c7f6b798be4ffc3c42c6"
+dependencies = [
+ "cfg-if",
+ "dashu-base",
+ "num-modular",
+ "rustversion",
+ "static_assertions",
+]
 
 [[package]]
 name = "divan-macros"
@@ -219,10 +344,17 @@ dependencies = [
  "arrayref",
  "codspeed-divan-compat",
  "const_for",
+ "hegeltest",
  "num-traits",
  "pastey",
  "seq-macro",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -239,6 +371,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core",
 ]
 
 [[package]]
@@ -254,6 +387,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hegeltest"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5701dedf265f0843636826fdbbb1fc93ae013ccd37dc52357a4c0a1bf14d003"
+dependencies = [
+ "crc32fast",
+ "dashu-int",
+ "hegeltest-c",
+ "hegeltest-macros",
+ "miniz_oxide",
+ "parking_lot",
+ "paste",
+ "rand",
+ "rustc-hash",
+ "tempfile",
+]
+
+[[package]]
+name = "hegeltest-c"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f2ed09c0cf2259e0660c87d5959fd41ad60fe676e074c64e0a7d0eb37ad209"
+dependencies = [
+ "cbindgen",
+ "crc32fast",
+ "dashu-int",
+ "miniz_oxide",
+ "parking_lot",
+ "rand",
+ "rustc-hash",
+ "tempfile",
+]
+
+[[package]]
+name = "hegeltest-macros"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34220b7df7a680766537f5ee6882c0dbef3a45fbe794c212520db2bbb19b79ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +446,12 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -291,10 +481,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
 
 [[package]]
 name = "nix"
@@ -309,6 +523,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-modular"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc41a1374056e9672221567958a66c16be12d0e2c1b408761e14d901c237d5e0"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +536,47 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
@@ -357,6 +618,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +679,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +696,18 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "seq-macro"
@@ -454,10 +759,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "statrs"
@@ -468,6 +794,12 @@ dependencies = [
  "approx",
  "num-traits",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -492,6 +824,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,6 +844,30 @@ checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -517,9 +886,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -528,14 +897,26 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.4",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "windows-link"
@@ -551,6 +932,12 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ seq-macro = "0.3"
 [dev-dependencies]
 arrayref = "0.3"
 divan = { package = "codspeed-divan-compat", version = "5.0" }
+hegeltest = "0.28.2"
 
 [lints.rust]
 warnings = "deny"

--- a/src/bitpacking.rs
+++ b/src/bitpacking.rs
@@ -270,8 +270,6 @@ impl_packing!(u64);
 #[cfg(test)]
 mod test {
     use core::array;
-    use core::fmt::Debug;
-    use seq_macro::seq;
 
     use super::*;
 
@@ -299,44 +297,4 @@ mod test {
             );
         }
     }
-
-    fn try_round_trip<T: BitPacking + Debug, const W: usize, const B: usize>() {
-        let mut values: [T; 1024] = [T::zero(); 1024];
-        for i in 0..1024 {
-            values[i] = T::from(i % (1 << (W % T::T))).unwrap();
-        }
-
-        let mut packed = [T::zero(); B];
-        BitPacking::pack::<W, B>(&values, &mut packed);
-
-        let mut unpacked = [T::zero(); 1024];
-        BitPacking::unpack::<W, B>(&packed, &mut unpacked);
-
-        assert_eq!(&unpacked, &values);
-
-        for i in 0..1024 {
-            assert_eq!(BitPacking::unpack_single::<W, B>(&packed, i), values[i]);
-            assert_eq!(
-                unsafe { BitPacking::unchecked_unpack_single(W, &packed, i) },
-                values[i]
-            );
-        }
-    }
-
-    macro_rules! impl_try_round_trip {
-        ($T:ty, $W:expr) => {
-            paste! {
-                #[test]
-                fn [<test_round_trip_ $T _ $W>]() {
-                    const B: usize = 1024 * $W / <$T>::T;
-                    try_round_trip::<$T, $W, B>();
-                }
-            }
-        };
-    }
-
-    seq!(W in 0..=8 { impl_try_round_trip!(u8, W); });
-    seq!(W in 0..=16 { impl_try_round_trip!(u16, W); });
-    seq!(W in 0..=32 { impl_try_round_trip!(u32, W); });
-    seq!(W in 0..=64 { impl_try_round_trip!(u64, W); });
 }

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -5,6 +5,7 @@ use fastlanes::BitPacking;
 use hegel::TestCase;
 use hegel::generators as gs;
 use hegel::generators::Integer;
+use pastey::paste;
 use std::fmt::Debug;
 
 const BUFFER_SIZE: usize = 1024;
@@ -15,19 +16,10 @@ where
 {
     let width = tc.draw(gs::integers::<usize>().min_value(0).max_value(T::T));
 
-    let max_value = if width == T::T {
-        T::max_value()
-    } else {
-        (T::one() << width) - T::one()
-    };
     let input = tc.draw(
-        gs::vecs(
-            gs::integers::<T>()
-                .min_value(T::zero())
-                .max_value(max_value),
-        )
-        .min_size(BUFFER_SIZE)
-        .max_size(BUFFER_SIZE),
+        gs::vecs(gs::integers::<T>())
+            .min_size(BUFFER_SIZE)
+            .max_size(BUFFER_SIZE),
     );
 
     // We use dirty buffers here, to make sure its not a hidden invariant
@@ -49,13 +41,6 @@ where
     let expected = input.iter().copied().map(|v| v & mask).collect::<Vec<_>>();
 
     assert_eq!(expected, unpacked_output);
-
-    for index in 0..BUFFER_SIZE {
-        assert_eq!(
-            unsafe { T::unchecked_unpack_single(width, &packed_output, index) },
-            expected[index],
-        );
-    }
 }
 
 fn assert_bitpack_repack_roundtrip<T>(tc: &TestCase)
@@ -80,37 +65,47 @@ where
     assert_eq!(packed_input, repacked_output);
 }
 
-macro_rules! bitpack_property_test {
-    ($name:ident, $type:ty, $property:ident) => {
-        #[hegel::test(test_cases = 1000)]
-        fn $name(tc: TestCase) {
-            $property::<$type>(&tc);
+fn assert_bitpack_unpack_single_matches_bulk<T>(tc: &TestCase)
+where
+    T: BitPacking + Debug + Integer + 'static,
+{
+    let width = tc.draw(gs::integers::<usize>().min_value(0).max_value(T::T));
+    let packed_length = (BUFFER_SIZE * width) / T::T;
+    let packed_input = tc.draw(
+        gs::vecs(gs::integers::<T>())
+            .min_size(packed_length)
+            .max_size(packed_length),
+    );
+    let index = tc.draw(
+        gs::integers::<usize>()
+            .min_value(0)
+            .max_value(BUFFER_SIZE - 1),
+    );
+
+    let mut unpacked_output = vec![T::one(); BUFFER_SIZE];
+    unsafe {
+        T::unchecked_unpack(width, &packed_input, &mut unpacked_output);
+    }
+
+    assert_eq!(
+        unsafe { T::unchecked_unpack_single(width, &packed_input, index) },
+        unpacked_output[index],
+    );
+}
+
+macro_rules! bitpack_property_tests {
+    ($property:ident for $($type:ident),+ $(,)?) => {
+        paste! {
+            $(
+                #[hegel::test(test_cases = 1000)]
+                fn [<test_ $property _ $type>](tc: TestCase) {
+                    [<assert_ $property>]::<$type>(&tc);
+                }
+            )+
         }
     };
 }
 
-bitpack_property_test!(test_bitpack_roundtrip_u8, u8, assert_bitpack_roundtrip);
-bitpack_property_test!(test_bitpack_roundtrip_u16, u16, assert_bitpack_roundtrip);
-bitpack_property_test!(test_bitpack_roundtrip_u32, u32, assert_bitpack_roundtrip);
-bitpack_property_test!(test_bitpack_roundtrip_u64, u64, assert_bitpack_roundtrip);
-
-bitpack_property_test!(
-    test_bitpack_repack_roundtrip_u8,
-    u8,
-    assert_bitpack_repack_roundtrip
-);
-bitpack_property_test!(
-    test_bitpack_repack_roundtrip_u16,
-    u16,
-    assert_bitpack_repack_roundtrip
-);
-bitpack_property_test!(
-    test_bitpack_repack_roundtrip_u32,
-    u32,
-    assert_bitpack_repack_roundtrip
-);
-bitpack_property_test!(
-    test_bitpack_repack_roundtrip_u64,
-    u64,
-    assert_bitpack_repack_roundtrip
-);
+bitpack_property_tests!(bitpack_roundtrip for u8, u16, u32, u64);
+bitpack_property_tests!(bitpack_repack_roundtrip for u8, u16, u32, u64);
+bitpack_property_tests!(bitpack_unpack_single_matches_bulk for u8, u16, u32, u64);

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -1,0 +1,116 @@
+// https://github.com/rust-lang/rust-clippy/issues/11024
+#![allow(clippy::tests_outside_test_module)]
+
+use fastlanes::BitPacking;
+use hegel::TestCase;
+use hegel::generators as gs;
+use hegel::generators::Integer;
+use std::fmt::Debug;
+
+const BUFFER_SIZE: usize = 1024;
+
+fn assert_bitpack_roundtrip<T>(tc: &TestCase)
+where
+    T: BitPacking + Debug + Integer + 'static,
+{
+    let width = tc.draw(gs::integers::<usize>().min_value(0).max_value(T::T));
+
+    let max_value = if width == T::T {
+        T::max_value()
+    } else {
+        (T::one() << width) - T::one()
+    };
+    let input = tc.draw(
+        gs::vecs(
+            gs::integers::<T>()
+                .min_value(T::zero())
+                .max_value(max_value),
+        )
+        .min_size(BUFFER_SIZE)
+        .max_size(BUFFER_SIZE),
+    );
+
+    // We use dirty buffers here, to make sure its not a hidden invariant
+    let mut packed_output = vec![T::one(); (BUFFER_SIZE * width) / T::T];
+    let mut unpacked_output = vec![T::one(); BUFFER_SIZE];
+    unsafe { BitPacking::unchecked_pack(width, &input, &mut packed_output) };
+    unsafe {
+        BitPacking::unchecked_unpack(width, &packed_output, &mut unpacked_output);
+    }
+
+    let mask = if width == 0 {
+        T::zero()
+    } else if width == T::T {
+        T::max_value()
+    } else {
+        (T::one() << width) - T::one()
+    };
+
+    let expected = input.iter().copied().map(|v| v & mask).collect::<Vec<_>>();
+
+    assert_eq!(expected, unpacked_output);
+
+    for index in 0..BUFFER_SIZE {
+        assert_eq!(
+            unsafe { T::unchecked_unpack_single(width, &packed_output, index) },
+            expected[index],
+        );
+    }
+}
+
+fn assert_bitpack_repack_roundtrip<T>(tc: &TestCase)
+where
+    T: BitPacking + Debug + Integer + 'static,
+{
+    let width = tc.draw(gs::integers::<usize>().min_value(0).max_value(T::T));
+    let packed_length = (BUFFER_SIZE * width) / T::T;
+    let packed_input = tc.draw(
+        gs::vecs(gs::integers::<T>())
+            .min_size(packed_length)
+            .max_size(packed_length),
+    );
+
+    let mut unpacked_output = vec![T::one(); BUFFER_SIZE];
+    let mut repacked_output = vec![T::one(); packed_length];
+    unsafe {
+        BitPacking::unchecked_unpack(width, &packed_input, &mut unpacked_output);
+        BitPacking::unchecked_pack(width, &unpacked_output, &mut repacked_output);
+    }
+
+    assert_eq!(packed_input, repacked_output);
+}
+
+macro_rules! bitpack_property_test {
+    ($name:ident, $type:ty, $property:ident) => {
+        #[hegel::test(test_cases = 1000)]
+        fn $name(tc: TestCase) {
+            $property::<$type>(&tc);
+        }
+    };
+}
+
+bitpack_property_test!(test_bitpack_roundtrip_u8, u8, assert_bitpack_roundtrip);
+bitpack_property_test!(test_bitpack_roundtrip_u16, u16, assert_bitpack_roundtrip);
+bitpack_property_test!(test_bitpack_roundtrip_u32, u32, assert_bitpack_roundtrip);
+bitpack_property_test!(test_bitpack_roundtrip_u64, u64, assert_bitpack_roundtrip);
+
+bitpack_property_test!(
+    test_bitpack_repack_roundtrip_u8,
+    u8,
+    assert_bitpack_repack_roundtrip
+);
+bitpack_property_test!(
+    test_bitpack_repack_roundtrip_u16,
+    u16,
+    assert_bitpack_repack_roundtrip
+);
+bitpack_property_test!(
+    test_bitpack_repack_roundtrip_u32,
+    u32,
+    assert_bitpack_repack_roundtrip
+);
+bitpack_property_test!(
+    test_bitpack_repack_roundtrip_u64,
+    u64,
+    assert_bitpack_repack_roundtrip
+);


### PR DESCRIPTION
This PR takes the roundtrip tests we have for bit-packing and replaces them with a [hegel][hegel](https://docs.rs/hegeltest) based property tests that also assert a few more characteristics.

Even at 1000 test cases for each individual test, the overall runtime locally is 3-4s