### PR TITLE
feat: Replace `std` feature with a `runtime` feature so its always `no_std`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         env:
           RUSTFLAGS: "-C target-feature=+avx2"
         run: |
-          cargo codspeed build --profile bench --features std
+          cargo codspeed build --profile bench --features runtime
 
       - name: Run benchmarks
         uses: CodSpeedHQ/action@f99becdce5e5d51fd556489ebef684f4ecfd6286 # v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,6 +344,7 @@ dependencies = [
  "arrayref",
  "codspeed-divan-compat",
  "const_for",
+ "cpufeatures",
  "hegeltest",
  "num-traits",
  "pastey",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,17 @@ exclude = [".github/*", "renovate.json", ".git/*"]
 default = []
 # Enables runtime CPU feature detection for `transpose_bits`/`untranspose_bits`
 # dispatch. Without it, the dispatch is resolved at compile time from the enabled
-# `target_feature`s, keeping the crate `no_std`.
-std = []
+# `target_feature`s.
+runtime = ["dep:cpufeatures"]
 
 [dependencies]
 const_for = "0.1"
-num-traits = "0.2"
+num-traits = { version = "0.2", default-features = false }
 pastey = "0.2"
 seq-macro = "0.3"
+
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+cpufeatures = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 arrayref = "0.3"
@@ -75,7 +78,7 @@ harness = false
 [[bench]]
 name = "bit_transpose"
 harness = false
-required-features = ["std"]
+required-features = ["runtime"]
 
 [[bench]]
 name = "rle"

--- a/src/bit_transpose/mod.rs
+++ b/src/bit_transpose/mod.rs
@@ -12,10 +12,10 @@
 //! # Choosing an implementation
 //!
 //! [`transpose_bits`] / [`untranspose_bits`] dispatch to the fastest available
-//! implementation. When the crate is built with the `std` feature this dispatch
-//! is performed at runtime via CPU feature detection; otherwise it is resolved at
-//! compile time from the enabled `target_feature`s, falling back to the portable
-//! scalar implementation.
+//! implementation. When the crate is built with the `runtime` feature this
+//! dispatch is performed at runtime via `no_std` CPU feature detection; otherwise
+//! it is resolved at compile time from the enabled `target_feature`s, falling back
+//! to the portable scalar implementation.
 //!
 //! Every implementation is also exposed directly so that a downstream crate can
 //! select one explicitly even in a `no_std` build: [`scalar`], [`x86`]
@@ -135,17 +135,15 @@ pub(crate) fn as_byte_array_mut(block: &mut [u64; 16]) -> &mut [u8; 128] {
 
 /// Whether the AVX-512 VBMI implementation should be used.
 ///
-/// Resolved at runtime with the `std` feature, otherwise at compile time.
+/// Resolved at runtime with the `runtime` feature, otherwise at compile time.
 #[cfg(target_arch = "x86_64")]
 #[inline]
 fn detect_vbmi() -> bool {
-    #[cfg(feature = "std")]
+    #[cfg(feature = "runtime")]
     {
-        std::is_x86_feature_detected!("avx512vbmi")
-            && std::is_x86_feature_detected!("avx512bw")
-            && std::is_x86_feature_detected!("avx512f")
+        x86::has_vbmi()
     }
-    #[cfg(not(feature = "std"))]
+    #[cfg(not(feature = "runtime"))]
     {
         cfg!(all(
             target_feature = "avx512vbmi",
@@ -157,15 +155,15 @@ fn detect_vbmi() -> bool {
 
 /// Whether the BMI2 implementation should be used.
 ///
-/// Resolved at runtime with the `std` feature, otherwise at compile time.
+/// Resolved at runtime with the `runtime` feature, otherwise at compile time.
 #[cfg(target_arch = "x86_64")]
 #[inline]
 fn detect_bmi2() -> bool {
-    #[cfg(feature = "std")]
+    #[cfg(feature = "runtime")]
     {
-        std::is_x86_feature_detected!("bmi2")
+        x86::has_bmi2()
     }
-    #[cfg(not(feature = "std"))]
+    #[cfg(not(feature = "runtime"))]
     {
         cfg!(target_feature = "bmi2")
     }

--- a/src/bit_transpose/x86.rs
+++ b/src/bit_transpose/x86.rs
@@ -25,22 +25,25 @@ use crate::bit_transpose::as_byte_array;
 use crate::bit_transpose::as_byte_array_mut;
 use crate::bit_transpose::group_perm::group_tables;
 
-/// Check if BMI2 is available (requires the `std` feature for runtime detection).
-#[cfg(feature = "std")]
+#[cfg(feature = "runtime")]
+cpufeatures::new!(bmi2, "bmi2");
+#[cfg(feature = "runtime")]
+cpufeatures::new!(vbmi, "avx512f", "avx512bw", "avx512vbmi");
+
+/// Check if BMI2 is available (requires the `runtime` feature).
+#[cfg(feature = "runtime")]
 #[inline]
 #[must_use]
 pub fn has_bmi2() -> bool {
-    std::is_x86_feature_detected!("bmi2")
+    bmi2::get()
 }
 
-/// Check if AVX-512 VBMI (+ F + BW) is available (requires the `std` feature).
-#[cfg(feature = "std")]
+/// Check if AVX-512 VBMI (+ F + BW) is available (requires the `runtime` feature).
+#[cfg(feature = "runtime")]
 #[inline]
 #[must_use]
 pub fn has_vbmi() -> bool {
-    std::is_x86_feature_detected!("avx512vbmi")
-        && std::is_x86_feature_detected!("avx512bw")
-        && std::is_x86_feature_detected!("avx512f")
+    vbmi::get()
 }
 
 /// Per-bit-position masks selecting one bit out of every byte of a `u64`.
@@ -300,16 +303,16 @@ unsafe fn untranspose_bits_vbmi_lt64<T: FastLanes>(input: &[u64; 16], output: &m
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "std")]
+    #[cfg(feature = "runtime")]
     use super::*;
-    #[cfg(feature = "std")]
+    #[cfg(feature = "runtime")]
     use crate::bit_transpose::generate_test_data;
-    #[cfg(feature = "std")]
+    #[cfg(feature = "runtime")]
     use crate::bit_transpose::transpose_bits_baseline;
-    #[cfg(feature = "std")]
+    #[cfg(feature = "runtime")]
     use crate::bit_transpose::untranspose_bits_baseline;
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "runtime")]
     #[test]
     fn test_bmi2_matches_baseline() {
         if !has_bmi2() {
@@ -331,7 +334,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "runtime")]
     #[test]
     fn test_bmi2_roundtrip() {
         if !has_bmi2() {
@@ -354,7 +357,7 @@ mod tests {
 
     /// The width-generic BMI2 untranspose must match the width-parameterized baseline for every
     /// element width.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "runtime")]
     #[test]
     fn test_bmi2_untranspose_all_widths_match_baseline() {
         fn check<T: FastLanes>() {
@@ -384,7 +387,7 @@ mod tests {
         check::<u64>();
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "runtime")]
     #[test]
     fn test_vbmi_matches_baseline() {
         if !has_vbmi() {
@@ -406,7 +409,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "runtime")]
     #[test]
     fn test_vbmi_roundtrip() {
         if !has_vbmi() {
@@ -429,7 +432,7 @@ mod tests {
 
     /// The width-generic VBMI untranspose must match the width-parameterized baseline for every
     /// element width.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "runtime")]
     #[test]
     fn test_vbmi_untranspose_all_widths_match_baseline() {
         fn check<T: FastLanes>() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,6 @@
 
 extern crate alloc;
 extern crate core;
-#[cfg(feature = "std")]
-extern crate std;
 
 use core::mem::size_of;
 use num_traits::{PrimInt, Unsigned};


### PR DESCRIPTION
As discussed in #153 