### PR TITLE
Transpose::transpose/untranspose and bit_transpose/untranspose have the same ordering

### DIFF
--- a/benches/bit_transpose.rs
+++ b/benches/bit_transpose.rs
@@ -36,27 +36,27 @@ fn bench_blocks(bencher: Bencher, op: impl Fn(&[u64; 16], &mut [u64; 16])) {
     });
 }
 
-#[divan::bench]
-fn scalar_transpose(bencher: Bencher) {
-    bench_blocks(bencher, fastlanes::scalar::transpose_bits);
-}
-
-/// Untranspose is generic over the element width `T`; benchmark each width separately. The mask
+/// Transpose is generic over the element width `T`; benchmark each width separately. The mask
 /// always factors into 16 groups of 8 bytes regardless of `T`, so per-arch the widths should be
 /// within noise of one another (only the gather/scatter index tables differ).
 #[divan::bench(types = [u8, u16, u32, u64])]
-fn scalar_untranspose<T: FastLanes>(bencher: Bencher) {
-    bench_blocks(bencher, fastlanes::scalar::untranspose_bits::<T>);
+fn scalar_transpose<T: FastLanes>(bencher: Bencher) {
+    bench_blocks(bencher, fastlanes::scalar::transpose_bits::<T>);
 }
 
 #[divan::bench]
-fn dispatch_transpose(bencher: Bencher) {
-    bench_blocks(bencher, fastlanes::transpose_bits);
+fn scalar_untranspose(bencher: Bencher) {
+    bench_blocks(bencher, fastlanes::scalar::untranspose_bits);
 }
 
 #[divan::bench(types = [u8, u16, u32, u64])]
-fn dispatch_untranspose<T: FastLanes>(bencher: Bencher) {
-    bench_blocks(bencher, fastlanes::untranspose_bits::<T>);
+fn dispatch_transpose<T: FastLanes>(bencher: Bencher) {
+    bench_blocks(bencher, fastlanes::transpose_bits::<T>);
+}
+
+#[divan::bench]
+fn dispatch_untranspose(bencher: Bencher) {
+    bench_blocks(bencher, fastlanes::untranspose_bits);
 }
 
 #[cfg(target_arch = "x86_64")]
@@ -65,43 +65,47 @@ mod x86 {
     use fastlanes::FastLanes;
     use fastlanes::x86;
 
-    #[divan::bench]
-    fn bmi2_transpose(bencher: Bencher) {
-        if !x86::has_bmi2() {
-            return;
-        }
-        // SAFETY: guarded by `has_bmi2`.
-        bench_blocks(bencher, |i, o| unsafe { x86::transpose_bits_bmi2(i, o) });
-    }
-
     #[divan::bench(types = [u8, u16, u32, u64])]
-    fn bmi2_untranspose<T: FastLanes>(bencher: Bencher) {
+    fn bmi2_transpose<T: FastLanes>(bencher: Bencher) {
         if !x86::has_bmi2() {
             return;
         }
         // SAFETY: guarded by `has_bmi2`.
         bench_blocks(bencher, |i, o| unsafe {
-            x86::untranspose_bits_bmi2::<T>(i, o);
+            x86::transpose_bits_bmi2::<T>(i, o)
         });
     }
 
     #[divan::bench]
-    fn vbmi_transpose(bencher: Bencher) {
-        if !x86::has_vbmi() {
+    fn bmi2_untranspose(bencher: Bencher) {
+        if !x86::has_bmi2() {
             return;
         }
-        // SAFETY: guarded by `has_vbmi`.
-        bench_blocks(bencher, |i, o| unsafe { x86::transpose_bits_vbmi(i, o) });
+        // SAFETY: guarded by `has_bmi2`.
+        bench_blocks(bencher, |i, o| unsafe {
+            x86::untranspose_bits_bmi2(i, o);
+        });
     }
 
     #[divan::bench(types = [u8, u16, u32, u64])]
-    fn vbmi_untranspose<T: FastLanes>(bencher: Bencher) {
+    fn vbmi_transpose<T: FastLanes>(bencher: Bencher) {
         if !x86::has_vbmi() {
             return;
         }
         // SAFETY: guarded by `has_vbmi`.
         bench_blocks(bencher, |i, o| unsafe {
-            x86::untranspose_bits_vbmi::<T>(i, o);
+            x86::transpose_bits_vbmi::<T>(i, o)
+        });
+    }
+
+    #[divan::bench]
+    fn vbmi_untranspose(bencher: Bencher) {
+        if !x86::has_vbmi() {
+            return;
+        }
+        // SAFETY: guarded by `has_vbmi`.
+        bench_blocks(bencher, |i, o| unsafe {
+            x86::untranspose_bits_vbmi(i, o);
         });
     }
 }
@@ -112,19 +116,19 @@ mod aarch64 {
     use fastlanes::FastLanes;
     use fastlanes::aarch64;
 
-    #[divan::bench]
-    fn neon_transpose(bencher: Bencher) {
+    #[divan::bench(types = [u8, u16, u32, u64])]
+    fn neon_transpose<T: FastLanes>(bencher: Bencher) {
         // SAFETY: NEON is always available on aarch64.
         bench_blocks(bencher, |i, o| unsafe {
-            aarch64::transpose_bits_neon(i, o);
+            aarch64::transpose_bits_neon::<T>(i, o);
         });
     }
 
-    #[divan::bench(types = [u8, u16, u32, u64])]
-    fn neon_untranspose<T: FastLanes>(bencher: Bencher) {
+    #[divan::bench]
+    fn neon_untranspose(bencher: Bencher) {
         // SAFETY: NEON is always available on aarch64.
         bench_blocks(bencher, |i, o| unsafe {
-            aarch64::untranspose_bits_neon::<T>(i, o);
+            aarch64::untranspose_bits_neon(i, o);
         });
     }
 }

--- a/benches/bit_transpose.rs
+++ b/benches/bit_transpose.rs
@@ -72,7 +72,7 @@ mod x86 {
         }
         // SAFETY: guarded by `has_bmi2`.
         bench_blocks(bencher, |i, o| unsafe {
-            x86::transpose_bits_bmi2::<T>(i, o)
+            x86::transpose_bits_bmi2::<T>(i, o);
         });
     }
 
@@ -94,7 +94,7 @@ mod x86 {
         }
         // SAFETY: guarded by `has_vbmi`.
         bench_blocks(bencher, |i, o| unsafe {
-            x86::transpose_bits_vbmi::<T>(i, o)
+            x86::transpose_bits_vbmi::<T>(i, o);
         });
     }
 

--- a/benches/bitpacking_cmp.rs
+++ b/benches/bitpacking_cmp.rs
@@ -7,7 +7,7 @@ fn main() {
 mod bench {
     use divan::Bencher;
     use fastlanes::{
-        BitPacking, BitPackingCompare, FastLanes, FastLanesComparable, untranspose_bits,
+        BitPacking, BitPackingCompare, FastLanes, FastLanesComparable, transpose_bits,
     };
     use num_traits::FromPrimitive;
     use std::hint::black_box;
@@ -51,7 +51,7 @@ mod bench {
                     black_box(value),
                 );
             }
-            untranspose_bits::<T>(black_box(&transposed), &mut logical);
+            transpose_bits::<T>(black_box(&transposed), &mut logical);
             black_box(&logical);
         });
     }

--- a/src/bit_transpose/aarch64.rs
+++ b/src/bit_transpose/aarch64.rs
@@ -114,13 +114,16 @@ unsafe fn bit_transpose_8x8_neon(mut v: uint64x2_t) -> uint64x2_t {
     veorq_u64(veorq_u64(v, t), vshlq_n_u64::<28>(t))
 }
 
-/// Transpose one 1024-bit block using NEON with TBL-based gather and scatter.
+/// Untranspose one 1024-bit block using NEON with TBL-based gather and scatter.
+///
+/// The bit-level equivalent of [`crate::Transpose::untranspose`]; the inverse of
+/// [`transpose_bits_neon::<u64>`](transpose_bits_neon).
 ///
 /// # Safety
 /// Requires `AArch64` with NEON (always available on `AArch64`).
 #[inline]
 #[allow(unsafe_op_in_unsafe_fn)]
-pub unsafe fn transpose_bits_neon(input: &[u64; 16], output: &mut [u64; 16]) {
+pub unsafe fn untranspose_bits_neon(input: &[u64; 16], output: &mut [u64; 16]) {
     let input = as_byte_array(input);
     let output = as_byte_array_mut(output);
 
@@ -195,17 +198,19 @@ unsafe fn permute_128(src: &[u8; 128], idx: &[u8; 128]) -> [u8; 128] {
     out
 }
 
-/// Untranspose a `T`-width comparison mask into logical row order using NEON.
+/// Transpose 1024 bits (a `T`-width comparison mask) into logical row order using NEON.
 ///
-/// Regardless of width the 128 bytes factor into 16 groups of 8 bytes, each an independent 8x8
-/// bit transpose (see [`crate::scalar::untranspose_bits`]). We TBL-gather the groups into
-/// group-major order, run the per-group 8x8 transpose, then TBL-scatter to logical positions.
+/// For `T = u64` this is the canonical `FastLanes` bit transpose, the bit-level equivalent of
+/// [`crate::Transpose::transpose`]. Regardless of width the 128 bytes factor into 16 groups of 8
+/// bytes, each an independent 8x8 bit transpose (see [`crate::scalar::transpose_bits`]). We
+/// TBL-gather the groups into group-major order, run the per-group 8x8 transpose, then
+/// TBL-scatter to logical positions.
 ///
 /// # Safety
 /// Requires `AArch64` with NEON (always available on `AArch64`).
 #[inline]
 #[allow(unsafe_op_in_unsafe_fn)]
-pub unsafe fn untranspose_bits_neon<T: FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
+pub unsafe fn transpose_bits_neon<T: FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
     let (gather_idx, scatter_idx) = group_tables::<T>();
 
     // Gather the 16 groups into contiguous group-major order.
@@ -234,14 +239,14 @@ mod tests {
     use hegel::generators as gs;
 
     #[hegel::test]
-    fn test_neon_matches_baseline(tc: TestCase) {
+    fn test_neon_untranspose_matches_baseline(tc: TestCase) {
         let input: [u64; 16] = tc.draw(gs::arrays(gs::integers::<u64>()));
         let mut baseline_out = [u64::MAX; 16];
         let mut tbl_out = [u64::MAX; 16];
 
-        transpose_bits_baseline(&input, &mut baseline_out);
+        untranspose_bits_baseline(&input, &mut baseline_out);
         // SAFETY: NEON is always available on aarch64.
-        unsafe { transpose_bits_neon(&input, &mut tbl_out) };
+        unsafe { untranspose_bits_neon(&input, &mut tbl_out) };
 
         assert_eq!(baseline_out, tbl_out);
     }
@@ -254,42 +259,42 @@ mod tests {
 
         // SAFETY: NEON is always available on aarch64.
         unsafe {
-            transpose_bits_neon(&input, &mut transposed);
-            untranspose_bits_neon::<u64>(&transposed, &mut roundtrip);
+            transpose_bits_neon::<u64>(&input, &mut transposed);
+            untranspose_bits_neon(&transposed, &mut roundtrip);
         }
 
         assert_eq!(input, roundtrip);
     }
 
     #[hegel::test]
-    fn test_untranspose_neon_matches_baseline(tc: TestCase) {
+    fn test_neon_transpose_matches_baseline(tc: TestCase) {
         let input: [u64; 16] = tc.draw(gs::arrays(gs::integers::<u64>()));
         let mut baseline_out = [u64::MAX; 16];
         let mut tbl_out = [u64::MAX; 16];
 
-        untranspose_bits_baseline::<u64>(&input, &mut baseline_out);
+        transpose_bits_baseline::<u64>(&input, &mut baseline_out);
         // SAFETY: NEON is always available on aarch64.
-        unsafe { untranspose_bits_neon::<u64>(&input, &mut tbl_out) };
+        unsafe { transpose_bits_neon::<u64>(&input, &mut tbl_out) };
 
         assert_eq!(baseline_out, tbl_out);
     }
 
-    /// The generic NEON untranspose must match the width-parameterized baseline for every
+    /// The generic NEON transpose must match the width-parameterized baseline for every
     /// element width.
     #[hegel::test]
-    fn test_untranspose_neon_all_widths_match_baseline(tc: TestCase) {
+    fn test_neon_transpose_all_widths_match_baseline(tc: TestCase) {
         fn check<T: FastLanes>(input: &[u64; 16]) {
             let mut baseline_out = [u64::MAX; 16];
             let mut tbl_out = [u64::MAX; 16];
 
-            untranspose_bits_baseline::<T>(input, &mut baseline_out);
+            transpose_bits_baseline::<T>(input, &mut baseline_out);
             // SAFETY: NEON is always available on aarch64.
-            unsafe { untranspose_bits_neon::<T>(input, &mut tbl_out) };
+            unsafe { transpose_bits_neon::<T>(input, &mut tbl_out) };
 
             assert_eq!(
                 baseline_out,
                 tbl_out,
-                "NEON untranspose != baseline for type={}",
+                "NEON transpose != baseline for type={}",
                 core::any::type_name::<T>()
             );
         }

--- a/src/bit_transpose/mod.rs
+++ b/src/bit_transpose/mod.rs
@@ -5,6 +5,12 @@
 //! RLE, and for transposing validity bitmaps. This module provides architecture
 //! specific implementations of both the transpose and its inverse.
 //!
+//! The bit-level permutation is the same one that [`crate::Transpose`] applies to
+//! elements: bit `i` of the output of [`transpose_bits`] is bit
+//! [`crate::transpose`]`(i)` of the input, exactly as `Transpose::transpose` sets
+//! `output[i] = input[transpose(i)]`. [`untranspose_bits`] is the inverse, matching
+//! `Transpose::untranspose`.
+//!
 //! The key insight is that each output byte is formed by extracting the SAME bit
 //! position from 8 different input bytes at stride 16. The input byte groups follow
 //! the [`crate::FL_ORDER`] permutation pattern.
@@ -46,14 +52,14 @@ pub(crate) const TRANSPOSE_2X2: u64 = 0x00AA_00AA_00AA_00AA;
 pub(crate) const TRANSPOSE_4X4: u64 = 0x0000_CCCC_0000_CCCC;
 pub(crate) const TRANSPOSE_8X8: u64 = 0x0000_0000_F0F0_F0F0;
 
-/// Group-major gather/scatter permutation tables shared by the SIMD width-generic untranspose
+/// Group-major gather/scatter permutation tables shared by the SIMD width-generic transpose
 /// kernels (NEON and AVX-512 VBMI). Only built for the architectures that have such a kernel.
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub(crate) mod group_perm {
     /// Byte-gather indices that pull the 8 bytes of every group into contiguous group-major order
     /// for an element width of `tb` bits. Group `g = lhi * (tb/8) + hi` collects byte `llo` of its
     /// lane words from input byte `lhi*tb + hi + llo*(tb/8)`. See
-    /// [`crate::bit_transpose::scalar::untranspose_bits`].
+    /// [`crate::bit_transpose::scalar::transpose_bits`].
     const fn gather_indices(tb: usize) -> [u8; 128] {
         let bytes = tb / 8;
         let mut idx = [0u8; 128];
@@ -169,59 +175,67 @@ fn detect_bmi2() -> bool {
     }
 }
 
+/// Untranspose 1024 bits out of `FastLanes` layout, dispatching to the best implementation.
+///
+/// This is the bit-level equivalent of [`crate::Transpose::untranspose`]: the inverse of
+/// [`transpose_bits::<u64>`](transpose_bits).
+#[inline]
+pub fn untranspose_bits(input: &[u64; 16], output: &mut [u64; 16]) {
+    #[cfg(target_arch = "x86_64")]
+    {
+        if detect_vbmi() {
+            // SAFETY: guarded by `detect_vbmi`.
+            unsafe { x86::untranspose_bits_vbmi(input, output) }
+        } else if detect_bmi2() {
+            // SAFETY: guarded by `detect_bmi2`.
+            unsafe { x86::untranspose_bits_bmi2(input, output) }
+        } else {
+            scalar::untranspose_bits(input, output);
+        }
+    }
+    #[cfg(target_arch = "aarch64")]
+    // SAFETY: NEON is always available on aarch64.
+    unsafe {
+        aarch64::untranspose_bits_neon(input, output);
+    }
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    scalar::untranspose_bits(input, output);
+}
+
 /// Transpose 1024 bits into `FastLanes` layout, dispatching to the best implementation.
+///
+/// For `T = u64` this is the canonical `FastLanes` bit transpose, the bit-level equivalent of
+/// [`crate::Transpose::transpose`]. Narrower `T` apply the per-width permutation that brings the
+/// `T`-width comparison mask produced by `unpack_cmp` into logical row order (see
+/// [`crate::BitPackingCompare::unpack_cmp`]).
 #[inline]
-pub fn transpose_bits(input: &[u64; 16], output: &mut [u64; 16]) {
+pub fn transpose_bits<T: crate::FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
     #[cfg(target_arch = "x86_64")]
     {
         if detect_vbmi() {
             // SAFETY: guarded by `detect_vbmi`.
-            unsafe { x86::transpose_bits_vbmi(input, output) }
+            unsafe { x86::transpose_bits_vbmi::<T>(input, output) }
         } else if detect_bmi2() {
             // SAFETY: guarded by `detect_bmi2`.
-            unsafe { x86::transpose_bits_bmi2(input, output) }
+            unsafe { x86::transpose_bits_bmi2::<T>(input, output) }
         } else {
-            scalar::transpose_bits(input, output);
+            scalar::transpose_bits::<T>(input, output);
         }
     }
     #[cfg(target_arch = "aarch64")]
     // SAFETY: NEON is always available on aarch64.
     unsafe {
-        aarch64::transpose_bits_neon(input, output);
+        aarch64::transpose_bits_neon::<T>(input, output);
     }
     #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
-    scalar::transpose_bits(input, output);
+    scalar::transpose_bits::<T>(input, output);
 }
 
-/// Untranspose a `T`-width comparison mask (1024 bits) from `FastLanes` layout into logical row
-/// order, dispatching to the best implementation. For `T = u64` this is the canonical `FastLanes`
-/// bit untranspose; narrower `T` undo the per-lane packing produced by `unpack_cmp` for that width.
-#[inline]
-pub fn untranspose_bits<T: crate::FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
-    #[cfg(target_arch = "x86_64")]
-    {
-        if detect_vbmi() {
-            // SAFETY: guarded by `detect_vbmi`.
-            unsafe { x86::untranspose_bits_vbmi::<T>(input, output) }
-        } else if detect_bmi2() {
-            // SAFETY: guarded by `detect_bmi2`.
-            unsafe { x86::untranspose_bits_bmi2::<T>(input, output) }
-        } else {
-            scalar::untranspose_bits::<T>(input, output);
-        }
-    }
-    #[cfg(target_arch = "aarch64")]
-    // SAFETY: NEON is always available on aarch64.
-    unsafe {
-        aarch64::untranspose_bits_neon::<T>(input, output);
-    }
-    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
-    scalar::untranspose_bits::<T>(input, output);
-}
-
-/// Reference transpose built directly on top of [`crate::transpose`], one bit at a time.
+/// Reference untranspose built directly on top of [`crate::transpose`], one bit at a time.
+///
+/// Mirrors [`crate::Transpose::untranspose`]: `output[transpose(i)] = input[i]`.
 #[cfg(test)]
-pub(crate) fn transpose_bits_baseline(input: &[u64; 16], output: &mut [u64; 16]) {
+pub(crate) fn untranspose_bits_baseline(input: &[u64; 16], output: &mut [u64; 16]) {
     let input = as_byte_array(input);
     let output = as_byte_array_mut(output);
     *output = [0u8; 128];
@@ -232,13 +246,14 @@ pub(crate) fn transpose_bits_baseline(input: &[u64; 16], output: &mut [u64; 16])
     }
 }
 
-/// Reference untranspose for a `T`-width comparison mask, one bit at a time.
+/// Reference transpose for a `T`-width comparison mask, one bit at a time.
 ///
 /// Mask bit `b = lane * T::T + row` holds the comparison for logical index `index(row, lane)`
 /// (the `unpack!` macro's formula), so we scatter each mask bit to its logical position. For
-/// `T = u64` this is exactly the inverse permutation of [`transpose_bits_baseline`].
+/// `T = u64` this is exactly [`crate::Transpose::transpose`] applied to bits
+/// (`output[i] = input[transpose(i)]`), and the inverse of [`untranspose_bits_baseline`].
 #[cfg(test)]
-pub(crate) fn untranspose_bits_baseline<T: crate::FastLanes>(
+pub(crate) fn transpose_bits_baseline<T: crate::FastLanes>(
     input: &[u64; 16],
     output: &mut [u64; 16],
 ) {
@@ -261,43 +276,109 @@ mod tests {
     use hegel::TestCase;
     use hegel::generators as gs;
 
+    /// Expand a 1024-bit block into 1024 elements, one bit per element.
+    fn bits_to_elements(bits: &[u64; 16]) -> [u64; 1024] {
+        let mut elements = [0u64; 1024];
+        for (i, element) in elements.iter_mut().enumerate() {
+            *element = (bits[i / 64] >> (i % 64)) & 1;
+        }
+        elements
+    }
+
+    /// Pack 1024 one-bit elements back into a 1024-bit block.
+    fn elements_to_bits(elements: &[u64; 1024]) -> [u64; 16] {
+        let mut bits = [0u64; 16];
+        for (i, &element) in elements.iter().enumerate() {
+            bits[i / 64] |= element << (i % 64);
+        }
+        bits
+    }
+
+    /// The bit-level transpose must apply the same permutation as the element-level
+    /// [`crate::Transpose::transpose`].
+    #[hegel::test]
+    fn test_transpose_bits_matches_element_transpose(tc: TestCase) {
+        let input: [u64; 16] = tc.draw(gs::arrays(gs::integers::<u64>()));
+
+        let mut expected_elements = [u64::MAX; 1024];
+        crate::Transpose::transpose(&bits_to_elements(&input), &mut expected_elements);
+
+        let mut out = [u64::MAX; 16];
+        transpose_bits::<u64>(&input, &mut out);
+
+        assert_eq!(out, elements_to_bits(&expected_elements));
+    }
+
+    /// The bit-level untranspose must apply the same permutation as the element-level
+    /// [`crate::Transpose::untranspose`].
+    #[hegel::test]
+    fn test_untranspose_bits_matches_element_untranspose(tc: TestCase) {
+        let input: [u64; 16] = tc.draw(gs::arrays(gs::integers::<u64>()));
+
+        let mut expected_elements = [u64::MAX; 1024];
+        crate::Transpose::untranspose(&bits_to_elements(&input), &mut expected_elements);
+
+        let mut out = [u64::MAX; 16];
+        untranspose_bits(&input, &mut out);
+
+        assert_eq!(out, elements_to_bits(&expected_elements));
+    }
+
+    /// Exhaustive one-hot check: input bit `transpose(i)` must land on output bit `i`, exactly
+    /// as `Transpose::transpose` sets `output[i] = input[transpose(i)]`.
+    #[test]
+    fn test_transpose_bits_one_hot_matches_transpose_index() {
+        for i in 0..1024 {
+            let src = crate::transpose(i);
+            let mut input = [0u64; 16];
+            input[src / 64] |= 1u64 << (src % 64);
+
+            let mut out = [u64::MAX; 16];
+            transpose_bits::<u64>(&input, &mut out);
+
+            let mut expected = [0u64; 16];
+            expected[i / 64] |= 1u64 << (i % 64);
+            assert_eq!(out, expected, "input bit {src} must land on output bit {i}");
+        }
+    }
+
     #[hegel::test]
     fn test_baseline_roundtrip(tc: TestCase) {
         let input: [u64; 16] = tc.draw(gs::arrays(gs::integers::<u64>()));
         let mut transposed = [u64::MAX; 16];
         let mut roundtrip = [u64::MAX; 16];
 
-        transpose_bits_baseline(&input, &mut transposed);
-        untranspose_bits_baseline::<u64>(&transposed, &mut roundtrip);
+        transpose_bits_baseline::<u64>(&input, &mut transposed);
+        untranspose_bits_baseline(&transposed, &mut roundtrip);
 
         assert_eq!(input, roundtrip);
     }
 
     #[hegel::test]
-    fn test_dispatch_matches_baseline(tc: TestCase) {
+    fn test_untranspose_dispatch_matches_baseline(tc: TestCase) {
         let input: [u64; 16] = tc.draw(gs::arrays(gs::integers::<u64>()));
         let mut baseline_out = [u64::MAX; 16];
         let mut out = [u64::MAX; 16];
 
-        transpose_bits_baseline(&input, &mut baseline_out);
-        transpose_bits(&input, &mut out);
+        untranspose_bits_baseline(&input, &mut baseline_out);
+        untranspose_bits(&input, &mut out);
 
         assert_eq!(baseline_out, out);
     }
 
     #[hegel::test]
-    fn test_untranspose_dispatch_matches_baseline(tc: TestCase) {
+    fn test_transpose_dispatch_matches_baseline(tc: TestCase) {
         fn check<T: crate::FastLanes>(input: &[u64; 16]) {
             let mut baseline_out = [u64::MAX; 16];
             let mut out = [u64::MAX; 16];
 
-            untranspose_bits_baseline::<T>(input, &mut baseline_out);
-            untranspose_bits::<T>(input, &mut out);
+            transpose_bits_baseline::<T>(input, &mut baseline_out);
+            transpose_bits::<T>(input, &mut out);
 
             assert_eq!(
                 baseline_out,
                 out,
-                "untranspose dispatch doesn't match baseline for type={}",
+                "transpose dispatch doesn't match baseline for type={}",
                 core::any::type_name::<T>()
             );
         }
@@ -314,8 +395,8 @@ mod tests {
         let mut transposed = [u64::MAX; 16];
         let mut roundtrip = [u64::MAX; 16];
 
-        transpose_bits(&input, &mut transposed);
-        untranspose_bits::<u64>(&transposed, &mut roundtrip);
+        transpose_bits::<u64>(&input, &mut transposed);
+        untranspose_bits(&transposed, &mut roundtrip);
 
         assert_eq!(input, roundtrip);
     }
@@ -329,11 +410,11 @@ mod tests {
     mod group_perm_tables {
         use super::*;
 
-        /// Portable scalar re-implementation of the SIMD width-generic untranspose, driven purely
+        /// Portable scalar re-implementation of the SIMD width-generic transpose, driven purely
         /// by the shared tables: gather the 16 byte-groups into group-major order, 8x8-transpose
         /// each group, then scatter back. Equivalent to the NEON/VBMI kernels but in plain Rust,
         /// so it validates the table *data* against the bit-level baseline on any host.
-        fn untranspose_via_tables<T: crate::FastLanes>(input: &[u64; 16]) -> [u64; 16] {
+        fn transpose_via_tables<T: crate::FastLanes>(input: &[u64; 16]) -> [u64; 16] {
             fn transpose_8x8(mut x: u64) -> u64 {
                 let t = (x ^ (x >> 7)) & TRANSPOSE_2X2;
                 x = x ^ t ^ (t << 7);
@@ -378,9 +459,9 @@ mod tests {
         fn tables_match_baseline_all_widths(tc: TestCase) {
             fn check<T: crate::FastLanes>(input: &[u64; 16]) {
                 let mut baseline = [u64::MAX; 16];
-                untranspose_bits_baseline::<T>(input, &mut baseline);
+                transpose_bits_baseline::<T>(input, &mut baseline);
                 assert_eq!(
-                    untranspose_via_tables::<T>(input),
+                    transpose_via_tables::<T>(input),
                     baseline,
                     "group_perm tables != baseline for type={}",
                     core::any::type_name::<T>()

--- a/src/bit_transpose/scalar.rs
+++ b/src/bit_transpose/scalar.rs
@@ -51,9 +51,12 @@ fn scatter(output: &mut [u8; 128], base: usize, val: u64) {
     }
 }
 
-/// Transpose one 1024-bit block using the scalar implementation.
+/// Untranspose one 1024-bit block using the scalar implementation.
+///
+/// The bit-level equivalent of [`crate::Transpose::untranspose`]; the inverse of
+/// [`transpose_bits::<u64>`](transpose_bits).
 #[inline]
-pub fn transpose_bits(input: &[u64; 16], output: &mut [u64; 16]) {
+pub fn untranspose_bits(input: &[u64; 16], output: &mut [u64; 16]) {
     let input = as_byte_array(input);
     let output = as_byte_array_mut(output);
     for (half, groups) in HALVES.iter().enumerate() {
@@ -66,19 +69,22 @@ pub fn transpose_bits(input: &[u64; 16], output: &mut [u64; 16]) {
     }
 }
 
-/// Untranspose a `T`-width comparison mask into logical row order, scalar implementation.
+/// Transpose one 1024-bit block into `FastLanes` layout, scalar implementation.
 ///
-/// The mask produced by `unpack_cmp` for an element width of `T::T` bits is laid out as
-/// `T::LANES` words of `T::T` bits (LSB-first per lane); the bit at position
-/// `lane * T::T + row` holds the comparison for logical index `index(row, lane)` (see the
-/// `unpack!` macro). This is the inverse of that permutation.
+/// For `T = u64` this is the canonical `FastLanes` bit transpose, the bit-level equivalent of
+/// [`crate::Transpose::transpose`] (`output[i] = input[transpose(i)]`).
+///
+/// Narrower `T` bring a `T`-width comparison mask into logical row order. The mask produced by
+/// `unpack_cmp` for an element width of `T::T` bits is laid out as `T::LANES` words of `T::T`
+/// bits (LSB-first per lane); the bit at position `lane * T::T + row` holds the comparison for
+/// logical index `index(row, lane)` (see the `unpack!` macro). This moves each mask bit to that
+/// logical index.
 ///
 /// Regardless of width the 128 bytes always factor into exactly 16 groups of 8 bytes, each
 /// group being an independent 8x8 bit transpose. The width only changes which input bytes form
-/// a group (the gather stride) and where the transposed bytes land (the scatter base). For
-/// `T = u64` this reduces to the canonical `FastLanes` bit untranspose.
+/// a group (the gather stride) and where the transposed bytes land (the scatter base).
 #[inline]
-pub fn untranspose_bits<T: FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
+pub fn transpose_bits<T: FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
     let input = as_byte_array(input);
     let output = as_byte_array_mut(output);
 
@@ -113,13 +119,13 @@ mod tests {
     use hegel::generators as gs;
 
     #[hegel::test]
-    fn test_scalar_matches_baseline(tc: TestCase) {
+    fn test_scalar_untranspose_matches_baseline(tc: TestCase) {
         let input: [u64; 16] = tc.draw(gs::arrays(gs::integers::<u64>()));
         let mut baseline_out = [u64::MAX; 16];
         let mut scalar_out = [u64::MAX; 16];
 
-        transpose_bits_baseline(&input, &mut baseline_out);
-        transpose_bits(&input, &mut scalar_out);
+        untranspose_bits_baseline(&input, &mut baseline_out);
+        untranspose_bits(&input, &mut scalar_out);
 
         assert_eq!(baseline_out, scalar_out);
     }
@@ -130,8 +136,8 @@ mod tests {
         let mut transposed = [u64::MAX; 16];
         let mut roundtrip = [u64::MAX; 16];
 
-        transpose_bits(&input, &mut transposed);
-        untranspose_bits::<u64>(&transposed, &mut roundtrip);
+        transpose_bits::<u64>(&input, &mut transposed);
+        untranspose_bits(&transposed, &mut roundtrip);
 
         assert_eq!(input, roundtrip);
     }
@@ -141,10 +147,10 @@ mod tests {
         let input = [0u64; 16];
         let mut output = [u64::MAX; 16];
 
-        transpose_bits(&input, &mut output);
+        transpose_bits::<u64>(&input, &mut output);
         assert_eq!(output, [0u64; 16]);
 
-        untranspose_bits::<u64>(&input, &mut output);
+        untranspose_bits(&input, &mut output);
         assert_eq!(output, [0u64; 16]);
     }
 
@@ -153,28 +159,28 @@ mod tests {
         let input = [u64::MAX; 16];
         let mut output = [0u64; 16];
 
-        transpose_bits(&input, &mut output);
+        transpose_bits::<u64>(&input, &mut output);
         assert_eq!(output, [u64::MAX; 16]);
 
-        untranspose_bits::<u64>(&input, &mut output);
+        untranspose_bits(&input, &mut output);
         assert_eq!(output, [u64::MAX; 16]);
     }
 
-    /// The generic untranspose must match the width-parameterized baseline for every element
+    /// The generic transpose must match the width-parameterized baseline for every element
     /// width, not just `u64`.
     #[hegel::test]
-    fn test_untranspose_all_widths_match_baseline(tc: TestCase) {
+    fn test_transpose_all_widths_match_baseline(tc: TestCase) {
         fn check<T: FastLanes>(input: &[u64; 16]) {
             let mut baseline_out = [u64::MAX; 16];
             let mut scalar_out = [u64::MAX; 16];
 
-            untranspose_bits_baseline::<T>(input, &mut baseline_out);
-            untranspose_bits::<T>(input, &mut scalar_out);
+            transpose_bits_baseline::<T>(input, &mut baseline_out);
+            transpose_bits::<T>(input, &mut scalar_out);
 
             assert_eq!(
                 baseline_out,
                 scalar_out,
-                "scalar untranspose != baseline for type={}",
+                "scalar transpose != baseline for type={}",
                 core::any::type_name::<T>()
             );
         }

--- a/src/bit_transpose/x86.rs
+++ b/src/bit_transpose/x86.rs
@@ -58,16 +58,18 @@ const BIT_MASKS: [u64; 8] = [
     0x8080_8080_8080_8080,
 ];
 
-/// Transpose 1024 bits using BMI2 `PEXT`.
+/// Untranspose 1024 bits using BMI2 `PEXT`.
 ///
-/// `PEXT` extracts bits at positions specified by a mask into contiguous low bits.
+/// The bit-level equivalent of [`crate::Transpose::untranspose`]; the inverse of
+/// [`transpose_bits_bmi2::<u64>`](transpose_bits_bmi2). `PEXT` extracts bits at positions
+/// specified by a mask into contiguous low bits.
 ///
 /// # Safety
 /// Requires BMI2 support. Check with [`has_bmi2`] before calling.
 #[target_feature(enable = "bmi2")]
 #[inline]
 #[allow(unsafe_op_in_unsafe_fn)]
-pub unsafe fn transpose_bits_bmi2(input: &[u64; 16], output: &mut [u64; 16]) {
+pub unsafe fn untranspose_bits_bmi2(input: &[u64; 16], output: &mut [u64; 16]) {
     let input = as_byte_array(input);
     let output = as_byte_array_mut(output);
 
@@ -81,21 +83,22 @@ pub unsafe fn transpose_bits_bmi2(input: &[u64; 16], output: &mut [u64; 16]) {
     }
 }
 
-/// Untranspose a `T`-width comparison mask (1024 bits) using BMI2 `PDEP`.
+/// Transpose 1024 bits (a `T`-width comparison mask) using BMI2 `PDEP`.
 ///
 /// Regardless of width the 128 bytes factor into 16 groups of 8 bytes, each an independent 8x8
-/// bit transpose (see [`crate::bit_transpose::scalar::untranspose_bits`]). The width only changes
+/// bit transpose (see [`crate::bit_transpose::scalar::transpose_bits`]). The width only changes
 /// the gather stride and the scatter base. For each group we gather its 8 bytes (at stride
 /// `T::T / 8`) and use `PDEP` to deposit byte `llo` into bit-position `llo` of all 8 packed
 /// output bytes — which is exactly the 8x8 bit transpose — then scatter the group at stride 16.
-/// For `T = u64` this is the canonical `FastLanes` bit untranspose.
+/// For `T = u64` this is the canonical `FastLanes` bit transpose, the bit-level equivalent of
+/// [`crate::Transpose::transpose`].
 ///
 /// # Safety
 /// Requires BMI2 support. Check with [`has_bmi2`] before calling.
 #[target_feature(enable = "bmi2")]
 #[inline]
 #[allow(unsafe_op_in_unsafe_fn)]
-pub unsafe fn untranspose_bits_bmi2<T: FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
+pub unsafe fn transpose_bits_bmi2<T: FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
     let input = as_byte_array(input);
     let output = as_byte_array_mut(output);
 
@@ -181,17 +184,19 @@ unsafe fn bit_transpose_8x8_zmm(mut v: __m512i) -> __m512i {
     _mm512_xor_si512(_mm512_xor_si512(v, t), _mm512_slli_epi64::<28>(t))
 }
 
-/// Transpose 1024 bits using AVX-512 VBMI for vectorized gather and scatter.
+/// Untranspose 1024 bits using AVX-512 VBMI for vectorized gather and scatter.
 ///
-/// Uses `vpermi2b` to gather bytes from stride-16 positions in parallel,
-/// and `vpermb` for the final 8x8 byte transpose to output format.
+/// The bit-level equivalent of [`crate::Transpose::untranspose`]; the inverse of
+/// [`transpose_bits_vbmi::<u64>`](transpose_bits_vbmi). Uses `vpermi2b` to gather bytes from
+/// stride-16 positions in parallel, and `vpermb` for the final 8x8 byte transpose to output
+/// format.
 ///
 /// # Safety
 /// Requires AVX-512F, AVX-512BW, and AVX-512VBMI support. Check with [`has_vbmi`].
 #[target_feature(enable = "avx512f", enable = "avx512bw", enable = "avx512vbmi")]
 #[inline]
 #[allow(clippy::cast_ptr_alignment, unsafe_op_in_unsafe_fn)]
-pub unsafe fn transpose_bits_vbmi(input: &[u64; 16], output: &mut [u64; 16]) {
+pub unsafe fn untranspose_bits_vbmi(input: &[u64; 16], output: &mut [u64; 16]) {
     let input = as_byte_array(input);
     let output = as_byte_array_mut(output);
 
@@ -212,32 +217,32 @@ pub unsafe fn transpose_bits_vbmi(input: &[u64; 16], output: &mut [u64; 16]) {
     }
 }
 
-/// Untranspose a `T`-width comparison mask (1024 bits) using AVX-512 VBMI.
+/// Transpose 1024 bits (a `T`-width comparison mask) using AVX-512 VBMI.
 ///
 /// Regardless of width the 128 bytes factor into 16 groups of 8 bytes, each an independent 8x8
 /// bit transpose. The `T = 64` block keeps the original kernel (gather within each 64-byte half
-/// with `vpermb`, then scatter); narrower widths use the width-generic [`untranspose_bits_vbmi_lt64`]
+/// with `vpermb`, then scatter); narrower widths use the width-generic [`transpose_bits_vbmi_lt64`]
 /// kernel whose groups span both halves. For `T = u64` this is the canonical `FastLanes` bit
-/// untranspose.
+/// transpose, the bit-level equivalent of [`crate::Transpose::transpose`].
 ///
 /// # Safety
 /// Requires AVX-512F, AVX-512BW, and AVX-512VBMI support. Check with [`has_vbmi`].
 #[target_feature(enable = "avx512f", enable = "avx512bw", enable = "avx512vbmi")]
 #[inline]
 #[allow(clippy::cast_ptr_alignment, unsafe_op_in_unsafe_fn)]
-pub unsafe fn untranspose_bits_vbmi<T: FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
+pub unsafe fn transpose_bits_vbmi<T: FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
     // `T::T` is a compile-time constant, so this branch is resolved at monomorphization and the
     // unused arm is eliminated. The `u64` arm is kept byte-identical to the original kernel.
     if T::T != 64 {
-        untranspose_bits_vbmi_lt64::<T>(input, output);
+        transpose_bits_vbmi_lt64::<T>(input, output);
         return;
     }
 
     let input = as_byte_array(input);
     let output = as_byte_array_mut(output);
 
-    // In the transposed layout the 8 bytes of a group are consecutive; this gather
-    // collects them into the eight u64 lanes of a ZMM register.
+    // In the untransposed (lane-major) layout the 8 bytes of a group are consecutive; this
+    // gather collects them into the eight u64 lanes of a ZMM register.
     let gather_indices: [u8; 64] = SCATTER_8X8;
     let idx = _mm512_loadu_si512(gather_indices.as_ptr().cast::<__m512i>());
 
@@ -256,7 +261,7 @@ pub unsafe fn untranspose_bits_vbmi<T: FastLanes>(input: &[u64; 16], output: &mu
     }
 }
 
-/// Width-generic (`T::T < 64`) VBMI untranspose for the narrow comparison-mask widths.
+/// Width-generic (`T::T < 64`) VBMI transpose for the narrow comparison-mask widths.
 ///
 /// Mirrors the width-generic NEON kernel: `vpermi2b` gathers the 16 eight-byte groups into
 /// group-major order across two ZMM registers (each 64-bit lane is one group), every lane is
@@ -269,7 +274,7 @@ pub unsafe fn untranspose_bits_vbmi<T: FastLanes>(input: &[u64; 16], output: &mu
 #[target_feature(enable = "avx512f", enable = "avx512bw", enable = "avx512vbmi")]
 #[inline]
 #[allow(clippy::cast_ptr_alignment, unsafe_op_in_unsafe_fn)]
-unsafe fn untranspose_bits_vbmi_lt64<T: FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
+unsafe fn transpose_bits_vbmi_lt64<T: FastLanes>(input: &[u64; 16], output: &mut [u64; 16]) {
     let input = as_byte_array(input);
     let output = as_byte_array_mut(output);
     let (gather_idx, scatter_idx) = group_tables::<T>();
@@ -312,7 +317,7 @@ mod tests {
     use hegel::generators as gs;
 
     #[hegel::test]
-    fn test_bmi2_matches_baseline(tc: TestCase) {
+    fn test_bmi2_untranspose_matches_baseline(tc: TestCase) {
         if !has_bmi2() {
             return;
         }
@@ -320,9 +325,9 @@ mod tests {
         let mut baseline_out = [u64::MAX; 16];
         let mut bmi2_out = [u64::MAX; 16];
 
-        transpose_bits_baseline(&input, &mut baseline_out);
+        untranspose_bits_baseline(&input, &mut baseline_out);
         // SAFETY: guarded by `has_bmi2`.
-        unsafe { transpose_bits_bmi2(&input, &mut bmi2_out) };
+        unsafe { untranspose_bits_bmi2(&input, &mut bmi2_out) };
 
         assert_eq!(baseline_out, bmi2_out);
     }
@@ -338,29 +343,29 @@ mod tests {
 
         // SAFETY: guarded by `has_bmi2`.
         unsafe {
-            transpose_bits_bmi2(&input, &mut transposed);
-            untranspose_bits_bmi2::<u64>(&transposed, &mut roundtrip);
+            transpose_bits_bmi2::<u64>(&input, &mut transposed);
+            untranspose_bits_bmi2(&transposed, &mut roundtrip);
         }
 
         assert_eq!(input, roundtrip);
     }
 
-    /// The width-generic BMI2 untranspose must match the width-parameterized baseline for every
+    /// The width-generic BMI2 transpose must match the width-parameterized baseline for every
     /// element width.
     #[hegel::test]
-    fn test_bmi2_untranspose_all_widths_match_baseline(tc: TestCase) {
+    fn test_bmi2_transpose_all_widths_match_baseline(tc: TestCase) {
         fn check<T: FastLanes>(input: &[u64; 16]) {
             let mut baseline_out = [u64::MAX; 16];
             let mut bmi2_out = [u64::MAX; 16];
 
-            untranspose_bits_baseline::<T>(input, &mut baseline_out);
+            transpose_bits_baseline::<T>(input, &mut baseline_out);
             // SAFETY: guarded by `has_bmi2`.
-            unsafe { untranspose_bits_bmi2::<T>(input, &mut bmi2_out) };
+            unsafe { transpose_bits_bmi2::<T>(input, &mut bmi2_out) };
 
             assert_eq!(
                 baseline_out,
                 bmi2_out,
-                "BMI2 untranspose != baseline for type={}",
+                "BMI2 transpose != baseline for type={}",
                 core::any::type_name::<T>()
             );
         }
@@ -375,7 +380,7 @@ mod tests {
     }
 
     #[hegel::test]
-    fn test_vbmi_matches_baseline(tc: TestCase) {
+    fn test_vbmi_untranspose_matches_baseline(tc: TestCase) {
         if !has_vbmi() {
             return;
         }
@@ -383,9 +388,9 @@ mod tests {
         let mut baseline_out = [u64::MAX; 16];
         let mut vbmi_out = [u64::MAX; 16];
 
-        transpose_bits_baseline(&input, &mut baseline_out);
+        untranspose_bits_baseline(&input, &mut baseline_out);
         // SAFETY: guarded by `has_vbmi`.
-        unsafe { transpose_bits_vbmi(&input, &mut vbmi_out) };
+        unsafe { untranspose_bits_vbmi(&input, &mut vbmi_out) };
 
         assert_eq!(baseline_out, vbmi_out);
     }
@@ -401,29 +406,29 @@ mod tests {
 
         // SAFETY: guarded by `has_vbmi`.
         unsafe {
-            transpose_bits_vbmi(&input, &mut transposed);
-            untranspose_bits_vbmi::<u64>(&transposed, &mut roundtrip);
+            transpose_bits_vbmi::<u64>(&input, &mut transposed);
+            untranspose_bits_vbmi(&transposed, &mut roundtrip);
         }
 
         assert_eq!(input, roundtrip);
     }
 
-    /// The width-generic VBMI untranspose must match the width-parameterized baseline for every
+    /// The width-generic VBMI transpose must match the width-parameterized baseline for every
     /// element width.
     #[hegel::test]
-    fn test_vbmi_untranspose_all_widths_match_baseline(tc: TestCase) {
+    fn test_vbmi_transpose_all_widths_match_baseline(tc: TestCase) {
         fn check<T: FastLanes>(input: &[u64; 16]) {
             let mut baseline_out = [u64::MAX; 16];
             let mut vbmi_out = [u64::MAX; 16];
 
-            untranspose_bits_baseline::<T>(input, &mut baseline_out);
+            transpose_bits_baseline::<T>(input, &mut baseline_out);
             // SAFETY: guarded by `has_vbmi`.
-            unsafe { untranspose_bits_vbmi::<T>(input, &mut vbmi_out) };
+            unsafe { transpose_bits_vbmi::<T>(input, &mut vbmi_out) };
 
             assert_eq!(
                 baseline_out,
                 vbmi_out,
-                "VBMI untranspose != baseline for type={}",
+                "VBMI transpose != baseline for type={}",
                 core::any::type_name::<T>()
             );
         }

--- a/src/bitpacking_cmp.rs
+++ b/src/bitpacking_cmp.rs
@@ -12,16 +12,17 @@ pub trait BitPackingCompare: FastLanes {
     /// `V::Bitpacked` = `Self`). This allows for comparison between signed values which are
     /// bit-packed as unsigned ones.
     ///
-    /// The output is a bitmask in **`FastLanes` (transposed) order**, not logical row order. The
-    /// `1024` bits are `Self::LANES` words of `Self::T` bits, one word per lane laid out
-    /// contiguously (little-endian) in the `[u64; 16]`. Within a lane's word the comparison
-    /// results are packed LSB-first: row `r` (for `r` in `0..Self::T`) lands at bit `r`, holding
-    /// the comparison for the value at logical index `index(row, lane)` (see the `unpack!` macro).
-    /// This is the cheapest order to produce: it needs no cross-lane shuffles, just a per-lane
-    /// accumulator that the compiler keeps in a (vectorized) register.
+    /// The output is a bitmask in **lane-major order**, not logical row order. The `1024` bits
+    /// are `Self::LANES` words of `Self::T` bits, one word per lane laid out contiguously
+    /// (little-endian) in the `[u64; 16]`. Within a lane's word the comparison results are packed
+    /// LSB-first: row `r` (for `r` in `0..Self::T`) lands at bit `r`, holding the comparison for
+    /// the value at logical index `index(row, lane)` (see the `unpack!` macro). This is the
+    /// cheapest order to produce: it needs no cross-lane shuffles, just a per-lane accumulator
+    /// that the compiler keeps in a (vectorized) register.
     ///
-    /// To recover logical row order (e.g. an Arrow-style boolean buffer), pass the result through
-    /// [`untranspose_cmp_mask`].
+    /// For `u64` this lane-major order is the bit-level [`crate::Transpose::untranspose`] of the
+    /// logical mask. To recover logical row order (e.g. an Arrow-style boolean buffer), pass the
+    /// result through [`crate::transpose_bits::<Self>`](crate::transpose_bits).
     fn unpack_cmp<const W: usize, const B: usize, V, F>(
         input: &[Self; B],
         output: &mut [u64; 16],
@@ -151,7 +152,7 @@ impl_packing_compare!(u64);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{BitPacking, untranspose_bits};
+    use crate::{BitPacking, transpose_bits};
     use alloc::{format, string::ToString, vec};
     use core::array;
     use core::fmt::Debug;
@@ -266,7 +267,7 @@ mod tests {
         }
     }
 
-    fn assert_unpack_cmp_untransposes_to_logical<T, V>(tc: &TestCase)
+    fn assert_unpack_cmp_transposes_to_logical<T, V>(tc: &TestCase)
     where
         T: BitPacking + BitPackingCompare + Debug + Integer + Send + Sync + 'static,
         V: Debug + FastLanesComparable<Bitpacked = T> + Integer + PartialOrd + 'static,
@@ -296,12 +297,12 @@ mod tests {
                     }
                 }
 
-                let mut transposed = [u64::MAX; 16];
+                let mut lane_major = [u64::MAX; 16];
                 unsafe {
-                    T::unchecked_unpack_cmp(width, &packed, &mut transposed, f, other);
+                    T::unchecked_unpack_cmp(width, &packed, &mut lane_major, f, other);
                 }
                 let mut actual = [u64::MAX; 16];
-                untranspose_bits::<T>(&transposed, &mut actual);
+                transpose_bits::<T>(&lane_major, &mut actual);
 
                 assert_eq!(
                     actual,
@@ -323,8 +324,8 @@ mod tests {
                 }
 
                 #[hegel::test(test_cases = 10)]
-                fn [<test_unpack_cmp_untransposes_to_logical_ $T _ $V>](tc: TestCase) {
-                    assert_unpack_cmp_untransposes_to_logical::<$T, $V>(&tc);
+                fn [<test_unpack_cmp_transposes_to_logical_ $T _ $V>](tc: TestCase) {
+                    assert_unpack_cmp_transposes_to_logical::<$T, $V>(&tc);
                 }
             }
         };


### PR DESCRIPTION
The two transpose family of functions run in opposite directions. We add test
to assert they match ordering
